### PR TITLE
Use nox to test in Python 3.7+

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,0 +1,52 @@
+name: Sphinx
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  sphinx:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+          architecture: "x64"
+          cache: "pip"
+      - name: Build Documentation
+        run: |
+          pip install -e .[docs]
+          make html
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: 'build/html'
+
+  pages:
+
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    needs: [sphinx]
+
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -22,6 +22,7 @@ jobs:
           cache: "pip"
       - name: Build Documentation
         run: |
+          pip install -r docs/requirements.txt
           make html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -22,7 +22,6 @@ jobs:
           cache: "pip"
       - name: Build Documentation
         run: |
-          pip install -e .[docs]
           make html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,24 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = docs
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
 style:
 	isort --profile=black .
 	black .

--- a/conda_index/__init__.py
+++ b/conda_index/__init__.py
@@ -2,4 +2,4 @@
 conda index. Create repodata.json for collections of conda packages.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(".."))
+
+
+# -- Project information -----------------------------------------------------
+
+project = "conda-index"
+copyright = "Anaconda, Inc."
+author = "Anaconda, Inc."
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx.ext.autodoc",
+    "myst_parser",
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "furo"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,16 @@
+# Welcome to conda-index's documentation!
+
+```{include} ../README.md
+```
+
+```{toctree}
+:caption: 'Contents:'
+:maxdepth: 2
+modules
+```
+
+# Indices and tables
+
+- {ref}`genindex`
+- {ref}`modindex`
+- {ref}`search`

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,8 @@
+# conda_index
+
+
+
+```{toctree}
+:maxdepth: 4
+
+```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+# docs
+furo
+sphinx
+myst-parser
+mdit-py-plugins>=0.3.0

--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=docs
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,12 @@
+import nox
+
+
+@nox.session(venv_backend="conda")
+@nox.parametrize(
+    "python",
+    [(python) for python in ("3.7", "3.8", "3.9", "3.10")],
+)
+def tests(session):
+    session.conda_install("conda", "conda-build")
+    session.install("-e", ".[test]")
+    session.run("pytest")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dynamic = ["version", "description"]
 requires-python = ">=3.9"
 dependencies = [
     "click >=8",
-    "conda >=4.12.0",
+    "conda >=4.12.0",   # not available on pypi
     "conda-package-streaming >=0.7.0",
     "filelock",
     "jinja2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ test = [
     "pytest-cov",
     "pytest-mock",
 ]
+docs = ["furo", "sphinx", "myst-parser", "mdit-py-plugins>=0.3.0"]
 
 [project.scripts]
 # conflicts with conda-build's conda-index... which script will win?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 license = { file = "LICENSE" }
 readme = "README.md"
 dynamic = ["version", "description"]
-requires-python = ">=3.9"
+requires-python = ">=3.7"   # TODO
 dependencies = [
     "click >=8",
     "conda >=4.12.0",   # not available on pypi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,24 +7,24 @@ name = "conda_index"
 authors = [
     { name = "Anaconda, Inc. & Contributors", email = "conda@continuum.io" },
 ]
-license = { "file" = "LICENSE" }
+license = { file = "LICENSE" }
 readme = "README.md"
 dynamic = ["version", "description"]
 requires-python = ">=3.9"
 dependencies = [
     "click >=8",
     "conda >=4.12.0",
-    "conda_package_streaming",
+    "conda-package-streaming >=0.7.0",
     "filelock",
     "jinja2",
-    "more_itertools",
+    "more-itertools",
     "PyYAML >=6",
 ]
 
 [project.optional-dependencies]
 test = [
     "conda-build >=3.21.0",
-    "conda-package-handling >=1.7.3",
+    "conda-package-handling >=1.9.0",
     "coverage[toml]",
     "pytest >=7",
     "pytest-cov",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ test:
     - pytest-cov
     - pytest-mock
   commands:
-    - pytest --cov
+    - pytest -k test_index_on_single_subdir_1
   imports:
     - conda_index.index
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,62 @@
+{% set name = "conda-index" %}
+{% set version_match = load_file_regex(
+  load_file="conda_index/__init__.py",
+  regex_pattern='__version__ = "(.+)"') %}
+{% set version = version_match[1] %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  git_url: ../
+  # url: https://github.com/conda/conda-index/archive/refs/tags/{{ version }}.tar.gz
+  # sha256: ...
+
+build:
+  script: {{ PYTHON }} -m pip install --no-build-isolation . -vv
+  number: 0
+  noarch: python
+
+requirements:
+  host:
+    - flit-core
+    - python >=3.7
+    - pip
+  run:
+    - python >=3.7  # 3.9?
+    - click >=8
+    - conda >=4.12.0
+    - conda-package-streaming
+    - filelock
+    - jinja2
+    - more-itertools
+    - PyYAML >=6
+
+test:
+  requires:
+    - conda-build >=3.21.0
+    - conda-package-handling >=1.9.0
+    - coverage[toml]
+    - pytest >=7
+    - pytest-cov
+    - pytest-mock
+  commands:
+    - pytest --cov
+  imports:
+    - conda_index.index
+  source_files:
+    - tests
+
+about:
+  home: https://github.com/conda/conda-index
+  summary: Create `repodata.json` for collections of conda packages.
+  license: BSD-3-Clause
+  license_file: LICENSE
+  doc_url: https://conda.github.io/conda-index
+  dev_url: https://github.com/conda/conda-index
+
+extra:
+  recipe-maintainers:
+    - dholth
+

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,6 @@ import shlex
 import sys
 
 import pytest
-from conda_build.conda_interface import PY3
 from conda_build.metadata import MetaData
 from conda_build.utils import on_win
 
@@ -28,17 +27,6 @@ def is_valid_dir(parent_dir, dirname):
     valid &= not dirname.startswith("_")
     valid &= "osx_is_app" != dirname or sys.platform == "darwin"
     return valid
-
-
-def add_mangling(filename):
-    if PY3:
-        filename = os.path.splitext(filename)[0] + ".cpython-{}{}.py".format(
-            sys.version_info.major, sys.version_info.minor
-        )
-        filename = os.path.join(
-            os.path.dirname(filename), "__pycache__", os.path.basename(filename)
-        )
-    return filename + "c"
 
 
 def assert_package_consistency(package_path):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

To test x86 on osx-arm64,

```
(create totally separate environment with x86 installer)
source ~/minicondax86/bin/activate
(install nox)
nox # in conda-index checkout
```

When running under arm, it will complain that Python 3.7 is not available.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
