### PR TITLE
remove conda-index console script to avoid conda-build conflict (use …

### DIFF
--- a/conda_index/__init__.py
+++ b/conda_index/__init__.py
@@ -2,4 +2,4 @@
 conda index. Create repodata.json for collections of conda packages.
 """
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ test = [
 docs = ["furo", "sphinx", "myst-parser", "mdit-py-plugins>=0.3.0"]
 
 [project.scripts]
-# conflicts with conda-build's conda-index... which script will win?
-conda-index = "conda_index.cli:cli"
+# conda-build also provides conda-index script.
+# require python -m conda_index for the moment to avoid the conflict.
 
 [project.urls]
 Home = "https://github.com/conda/conda-index"


### PR DESCRIPTION
…python -m conda_index)

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Remove conda-index script (conda-build also wants to provide the same script)

A future conda-index release will find a better way to resolve this conflict. Possibly the one that removes conda-index from conda-build.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
