### PR TITLE
remove conda < 4.13 fallback

### DIFF
--- a/conda_index/index/__init__.py
+++ b/conda_index/index/__init__.py
@@ -335,18 +335,16 @@ def _get_resolve_object(subdir, precs=None, repodata=None):
 
     channel = Channel("https://conda.anaconda.org/dummy-channel/%s" % subdir)
     sd = SubdirData(channel)
-    try:
-        # the next version of conda >= 4.13.0
-        # repodata = copy.deepcopy(repodata) # slower than json.dumps/load loop
-        repodata_copy = repodata.copy()
-        for group in ("packages", "packages.conda"):
-            repodata_copy[group] = {
-                key: value.copy() for key, value in repodata.get(group, {}).items()
-            }
-        # adds url, Channel objects to each repodata package
-        sd._process_raw_repodata(repodata_copy)  # type: ignore
-    except AttributeError:
-        sd._process_raw_repodata_str(json.dumps(repodata))
+
+    # repodata = copy.deepcopy(repodata) # slower than json.dumps/load loop
+    repodata_copy = repodata.copy()
+    for group in ("packages", "packages.conda"):
+        repodata_copy[group] = {
+            key: value.copy() for key, value in repodata.get(group, {}).items()
+        }
+    # adds url, Channel objects to each repodata package
+    sd._process_raw_repodata(repodata_copy)
+
     sd._loaded = True
     SubdirData._cache_[channel.url(with_credentials=True)] = sd
 

--- a/news/require-conda-4.14
+++ b/news/require-conda-4.14
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Require conda >= 4.14 (or any of the >= 22.x.y calver releases)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dynamic = ["version", "description"]
 requires-python = ">=3.7"
 dependencies = [
     "click >=8",
-    "conda >=4.12.0",   # not available on pypi
+    "conda >=4.14.0",   # not available on pypi
     "conda-package-streaming >=0.7.0",
     "filelock",
     "jinja2",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
   run:
     - python >=3.7
     - click >=8
-    - conda >=4.12.0
+    - conda >=4.14.0
     - conda-package-streaming
     - filelock
     - jinja2


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

conda added a process_repodata function that lets us avoid `json.dumps()`. Remove fallback for missing function.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
