### PR TITLE
remove missing conda-build variable from test suite

### DIFF
--- a/conda_index/__init__.py
+++ b/conda_index/__init__.py
@@ -2,4 +2,4 @@
 conda index. Create repodata.json for collections of conda packages.
 """
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import conda_package_handling.api
 import pytest
 import zstandard
-from conda_build.conda_interface import conda_47, context
+from conda_build.conda_interface import context
 from conda_build.utils import copy_into, rm_rf
 
 import conda_index.api
@@ -965,30 +965,25 @@ def test_current_index_reduces_space(index_data):
         "ancient-package-1.2.10-h7b6447c_3.tar.bz2",
         "one-gets-filtered-1.3.10-h7b6447c_3.tar.bz2",
     }
-    # conda 4.7 removes .tar.bz2 files in favor of .conda files
-    if conda_47:
-        tar_bz2_keys.remove("one-gets-filtered-1.3.10-h7b6447c_3.tar.bz2")
+    # conda 4.7+ removes .tar.bz2 files in favor of .conda files
+    tar_bz2_keys.remove("one-gets-filtered-1.3.10-h7b6447c_3.tar.bz2")
 
     # .conda files will replace .tar.bz2 files.  Older packages that are necessary for satisfiability will remain
     assert set(trimmed_repodata["packages"].keys()) == tar_bz2_keys
-    if conda_47:
-        assert set(trimmed_repodata["packages.conda"].keys()) == {
-            "one-gets-filtered-1.3.10-h7b6447c_3.conda"
-        }
+
+    assert set(trimmed_repodata["packages.conda"].keys()) == {
+        "one-gets-filtered-1.3.10-h7b6447c_3.conda"
+    }
 
     # we can keep more than one version series using a collection of keys
     trimmed_repodata = conda_index.index._build_current_repodata(
         "linux-64", repodata, {"one-gets-filtered": ["1.2", "1.3"]}
     )
-    if conda_47:
-        assert set(trimmed_repodata["packages.conda"].keys()) == {
-            "one-gets-filtered-1.2.11-h7b6447c_3.conda",
-            "one-gets-filtered-1.3.10-h7b6447c_3.conda",
-        }
-    else:
-        assert set(trimmed_repodata["packages"].keys()) == tar_bz2_keys | {
-            "one-gets-filtered-1.2.11-h7b6447c_3.tar.bz2"
-        }
+
+    assert set(trimmed_repodata["packages.conda"].keys()) == {
+        "one-gets-filtered-1.2.11-h7b6447c_3.conda",
+        "one-gets-filtered-1.3.10-h7b6447c_3.conda",
+    }
 
 
 def test_current_index_version_keys_keep_older_packages(index_data):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

"is conda47 or newer" variable was removed from conda-build.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
