### PR TITLE
Add weekly preventative testing; change canary build to noarch

### DIFF
--- a/.github/workflows/canary-weekly.yml
+++ b/.github/workflows/canary-weekly.yml
@@ -12,9 +12,22 @@ concurrency:
 
 jobs:
   linux:
-    # Allow manually-triggered run on fork or scheduled run on main repository:
+    # - this is a fork and manually-triggered, or
+    # - this is the main repo, and
+    # - we are on the main (or feature) branch
     if: >-
-      github.event_name != 'schedule' || !github.event.repository.fork
+      (
+        github.event.repository.fork
+        && github.event_name == 'workflow_dispatch'
+      )
+      || (
+        !github.event.repository.fork
+        && (
+          github.ref_name == 'main'
+          || startsWith(github.ref_name, 'feature/')
+        )
+      )
+
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/canary-weekly.yml
+++ b/.github/workflows/canary-weekly.yml
@@ -1,6 +1,7 @@
 name: Periodic Canary Build
 
 on:
+  workflow_dispatch:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron: "17 14 * * WED"

--- a/.github/workflows/canary-weekly.yml
+++ b/.github/workflows/canary-weekly.yml
@@ -1,0 +1,76 @@
+name: Periodic Canary Build
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "17 14 * * WED"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  linux:
+    if: >-
+        !github.event.repository.fork
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          channels: conda-canary defaults
+          activate-environment: test_env
+          auto-update-conda: true
+          auto-activate-base: false
+          show-channel-urls: true
+
+      - name: Source Scripts
+        run: |
+          conda install conda-build pip
+          # pip >=22 is required for pip install -e conda-index
+          pip install --upgrade pip
+          pip install -e .[test]
+          conda info -a
+          pytest
+
+  analyze:
+    name: Analyze test results
+    needs: [linux]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download test results
+        uses: actions/download-artifact@v3
+
+      - name: Upload combined test results
+        # provides one downloadable archive of all .coverage/test-report.xml files
+        # of all matrix runs for further analysis.
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results-${{ github.sha }}-all
+          path: test-results-${{ github.sha }}-*
+          retention-days: 90 # default: 90
+
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: ./test-results-${{ github.sha }}-**/test-report*.xml
+
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/canary-weekly.yml
+++ b/.github/workflows/canary-weekly.yml
@@ -42,9 +42,8 @@ jobs:
 
       - name: Source Scripts
         run: |
-          conda install -c conda-canary/label/dev conda-build pip
           # pip >=22 is required for pip install -e conda-index
-          pip install --upgrade pip
+          conda install -c conda-canary/label/dev conda-build "pip>=22"
           pip install -e .[test]
           conda info -a
           pytest

--- a/.github/workflows/canary-weekly.yml
+++ b/.github/workflows/canary-weekly.yml
@@ -12,8 +12,9 @@ concurrency:
 
 jobs:
   linux:
+    # Allow manually-triggered run on fork or scheduled run on main repository:
     if: >-
-        !github.event.repository.fork
+      github.event_name != 'schedule' || !github.event.repository.fork
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/canary-weekly.yml
+++ b/.github/workflows/canary-weekly.yml
@@ -33,7 +33,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
-          channels: conda-canary defaults
+          channels: conda-canary/label/dev
           activate-environment: test_env
           auto-update-conda: true
           auto-activate-base: false
@@ -41,7 +41,7 @@ jobs:
 
       - name: Source Scripts
         run: |
-          conda install conda-build pip
+          conda install -c conda-canary/label/dev conda-build pip
           # pip >=22 is required for pip install -e conda-index
           pip install --upgrade pip
           pip install -e .[test]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,7 @@ jobs:
         uses: conda/actions/canary-release@v22.10.0
         with:
           package-name: ${{ github.event.repository.name }}
-          subdir: linux-64
+          subdir: noarch
           anaconda-org-channel: conda-canary
           anaconda-org-label: ${{ github.ref_name == 'main' && 'dev' || github.ref_name }}
           anaconda-org-token: ${{ secrets.ANACONDA_ORG_CONDA_CANARY_TOKEN }}


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Canary build failed due to wrong subdir; the first party recipe is noarch. Will it succeed in noarch?

The manual-or-cron-triggered tests appear to be working over here https://github.com/dholth/conda-index/actions/workflows/canary-weekly.yml but do not appear to install the canary version of conda. At least today, they do install a new enough conda-build to catch the case I was interested in.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
