### PR TITLE
Implement CEP-12 to generate `run_exports.json`

### DIFF
--- a/conda_index/api.py
+++ b/conda_index/api.py
@@ -16,6 +16,7 @@ def update_index(
     verbose=False,
     progress=False,
     current_index_versions=None,
+    write_run_exports=False,
 ):
     import os
 
@@ -47,4 +48,5 @@ def update_index(
             progress=progress,
             subdirs=ensure_list(subdir),
             current_index_versions=current_index_versions,
+            write_run_exports=write_run_exports,
         )

--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -58,6 +58,12 @@ from .. import yaml
     show_default=True,
 )
 @click.option(
+    "--run-exports/--no-run-exports",
+    help="Write run_exports.json.",
+    default=False,
+    show_default=True,
+)
+@click.option(
     "--current-index-versions-file",
     "-m",
     help="""
@@ -85,6 +91,7 @@ def cli(
     bz2=False,
     zst=False,
     rss=False,
+    run_exports=False,
 ):
     logutil.configure()
     if verbose:
@@ -101,6 +108,7 @@ def cli(
         write_bz2=bz2,
         write_zst=zst,
         threads=threads,
+        write_run_exports=run_exports,
     )
 
     current_index_versions = None

--- a/conda_index/index/__init__.py
+++ b/conda_index/index/__init__.py
@@ -1082,7 +1082,7 @@ class ChannelIndex:
 
     def build_run_exports_data(self, subdir, verbose=False, progress=False):
         """
-        Return repodata from the cache without reading old repodata.json
+        Return CEP-12 compliant run_exports metadata from the db cache.
 
         Must call `extract_subdir_to_cache()` first or will be outdated.
         """

--- a/news/110-run-exports
+++ b/news/110-run-exports
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add `--run-exports` to generate CEP-12 compliant `run_exports.json` documents for each subdir. (#102 via #110)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -712,7 +712,6 @@ def test_patch_from_tarball(testing_workdir):
 
 
 def test_index_of_removed_pkg(testing_metadata):
-
     archive_name = "test_index_of_removed_pkg-1.0-1.tar.bz2"
     archive_destination = os.path.join(
         testing_metadata.config.croot, TEST_SUBDIR, archive_name
@@ -1069,3 +1068,57 @@ def test_index_clears_changed_packages(testing_workdir):
         channel_root=testing_workdir, subdir="osx-64"
     )
     assert list(index_cache.changed_packages()) == []
+
+
+def test_no_run_exports(index_data):
+    pkg_dir = os.path.join(index_data, "packages")
+    conda_index.api.update_index(pkg_dir, write_run_exports=False)
+    for subdir in ("osx-64", "noarch"):
+        assert not os.path.isfile(os.path.join(pkg_dir, subdir, "run_exports.json"))
+
+
+def test_run_exports(index_data):
+    pkg_dir = os.path.join(index_data, "packages")
+    conda_index.api.update_index(pkg_dir, write_run_exports=True)
+
+    noarch_run_exports_path = os.path.join(pkg_dir, "noarch", "run_exports.json")
+    assert os.path.isfile(noarch_run_exports_path)
+    with open(noarch_run_exports_path) as f:
+        noarch_data = json.load(f)
+
+    # Test data defines two packages with run_exports in noarch
+    assert noarch_data["info"]["subdir"] == "noarch"
+    assert noarch_data["info"]["version"] == 1
+    assert "packages" in noarch_data
+    assert "packages.conda" in noarch_data
+    seen = 0
+    for pkg in noarch_data["packages"]:
+        if pkg.startswith("run_exports_versions-1.0-"):
+            assert noarch_data["packages"][pkg]["run_exports"] == {
+                "weak": ["run_exports_version 1.0"]
+            }
+            seen += 1
+        elif pkg.startswith("run_exports_versions-2.0-"):
+            assert noarch_data["packages"][pkg]["run_exports"] == {
+                "weak": ["run_exports_version 2.0"]
+            }
+            seen += 1
+    assert seen == 2
+
+    # In osx-64, there're two packages with no run_exports, but they should also be listed
+    # with an empty run_exports dict
+    osx64_run_exports_path = os.path.join(pkg_dir, "osx-64", "run_exports.json")
+    assert os.path.isfile(osx64_run_exports_path)
+    with open(osx64_run_exports_path) as f:
+        osx64_data = json.load(f)
+
+    assert osx64_data["info"]["subdir"] == "osx-64"
+    assert osx64_data["info"]["version"] == 1
+    assert "packages" in osx64_data
+    assert "packages.conda" in osx64_data
+    seen = 0
+    for pkg in osx64_data["packages"]:
+        if pkg.startswith("dummy-package-"):
+            assert osx64_data["packages"][pkg]["run_exports"] == {}
+            seen += 1
+    assert seen == 2


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Following approval of CEP-12, this PR implements how to generate the `run_exports.json` documents along `repodata.json`.

* New API kwargs: `write_run_exports=<bool>` (defaults to false)
* New CLI flags: `--run-exports / --no-run-exports`

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
