### PR TITLE
Add `conda index` plugin

### DIFF
--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -11,7 +11,7 @@ from conda_index.index import MAX_THREADS_DEFAULT, ChannelIndex, logutil
 from .. import yaml
 
 
-@click.command()
+@click.command(context_settings={"help_option_names": ['-h', '--help']})
 @click.argument("dir")
 @click.option("--output", help="Output repodata to given directory.")
 @click.option(

--- a/conda_index/plugin.py
+++ b/conda_index/plugin.py
@@ -1,5 +1,5 @@
 """
-Conda command plugin, provide "conda reindex" command, renamed to
+Conda command plugin, provide "conda index" command, renamed to
 avoid clash with old "conda index" CLI.
 """
 

--- a/conda_index/plugin.py
+++ b/conda_index/plugin.py
@@ -11,6 +11,17 @@ def command(args):
 
 @conda.plugins.hookimpl
 def conda_subcommands():
+    # only expose plugin if conda-build>=24.1.0
+    try:
+        import conda_build
+        from packaging.version import parse
+
+        if parse(conda_build.__version__) < parse("24.1.0"):
+            return
+    except ImportError:
+        # ImportError: conda-build is not installed
+        pass
+
     yield conda.plugins.CondaSubcommand(
         name="index",
         action=command,

--- a/conda_index/plugin.py
+++ b/conda_index/plugin.py
@@ -5,7 +5,7 @@ avoid clash with old "conda index" CLI.
 
 import conda.plugins
 
-def command(*args):
+def command(args):
      import conda_index.cli
      return conda_index.cli.cli(prog_name="conda reindex", args=args)
 

--- a/conda_index/plugin.py
+++ b/conda_index/plugin.py
@@ -1,0 +1,19 @@
+"""
+Conda command plugin, provide "conda reindex" command, renamed to
+avoid clash with old "conda index" CLI.
+"""
+
+import conda.plugins
+
+def command(arguments: list[str]):
+     import conda_index.cli
+     conda_index.cli.cli()
+
+@conda.plugins.hookimpl
+def conda_subcommands():
+    yield conda.plugins.CondaSubcommand(
+        name="reindex",
+        action=command,
+        summary="Update package index metadata files.  Replaces `conda index`."
+    )
+

--- a/conda_index/plugin.py
+++ b/conda_index/plugin.py
@@ -5,9 +5,9 @@ avoid clash with old "conda index" CLI.
 
 import conda.plugins
 
-def command(arguments: list[str]):
+def command(*args):
      import conda_index.cli
-     conda_index.cli.cli()
+     return conda_index.cli.cli()
 
 @conda.plugins.hookimpl
 def conda_subcommands():

--- a/conda_index/plugin.py
+++ b/conda_index/plugin.py
@@ -7,7 +7,7 @@ import conda.plugins
 
 def command(*args):
      import conda_index.cli
-     return conda_index.cli.cli()
+     return conda_index.cli.cli(prog_name="conda reindex", args=args)
 
 @conda.plugins.hookimpl
 def conda_subcommands():

--- a/conda_index/plugin.py
+++ b/conda_index/plugin.py
@@ -12,8 +12,8 @@ def command(args):
 @conda.plugins.hookimpl
 def conda_subcommands():
     yield conda.plugins.CondaSubcommand(
-        name="reindex",
+        name="index",
         action=command,
-        summary="Update package index metadata files.  Replaces `conda index`."
+        summary="Update package index metadata files."
     )
 

--- a/conda_index/plugin.py
+++ b/conda_index/plugin.py
@@ -11,7 +11,7 @@ def command(args):
 
 @conda.plugins.hookimpl
 def conda_subcommands():
-    # only expose plugin if conda-build>=24.1.0
+    # hide plugin if conda-build<24.1.0
     try:
         import conda_build
         from packaging.version import parse

--- a/conda_index/plugin.py
+++ b/conda_index/plugin.py
@@ -2,12 +2,12 @@
 Conda command plugin, provide "conda index" command, renamed to
 avoid clash with old "conda index" CLI.
 """
-
 import conda.plugins
 
 def command(args):
      import conda_index.cli
-     return conda_index.cli.cli(prog_name="conda reindex", args=args)
+     return conda_index.cli.cli(prog_name="conda index", args=args)
+
 
 @conda.plugins.hookimpl
 def conda_subcommands():
@@ -16,4 +16,3 @@ def conda_subcommands():
         action=command,
         summary="Update package index metadata files."
     )
-

--- a/news/81-index-subcommand
+++ b/news/81-index-subcommand
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add an `index` subcommand using conda's new subcommand plugin hook. (#81 via #131)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,8 @@ docs = [
 # conda-build also provides conda-index script.
 # require python -m conda_index for the moment to avoid the conflict.
 
-[project.entry-points."conda"]
-reindex = "conda_index.plugin"
+[project.entry-points.conda]
+index = "conda_index.plugin"
 
 [project.urls]
 Home = "https://github.com/conda/conda-index"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ docs = [
 # conda-build also provides conda-index script.
 # require python -m conda_index for the moment to avoid the conflict.
 
+[project.entry-points."conda"]
+reindex = "conda_index.plugin"
+
 [project.urls]
 Home = "https://github.com/conda/conda-index"
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fix #81 

Note that this has a different CLI than the old "conda-index" command and would generally break conda-index scripts. This uses a click CLI and is more explicit. For example it won't automatically index the current directory if passed no arguments. For that reason we have been recommending `python -m conda_index` to use the many-times-faster standalone conda-index.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
