### PR TITLE
Add fsspec requirement to meta.yaml test dependencies

### DIFF
--- a/.github/workflows/canary-weekly.yml
+++ b/.github/workflows/canary-weekly.yml
@@ -1,4 +1,4 @@
-name: Periodic Canary Build
+name: Periodic Test Run
 
 on:
   workflow_dispatch:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ test:
     - conda-build >=3.21.0
     - conda-package-handling >=1.9.0
     - coverage
+    - fsspec
     - pytest >=7
     - pytest-cov
     - pytest-mock


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fix canary build; test suite imports fsspec but the single test we run in conda-build doesn't use `fsspec[http]` for example.

Rename weekly test runner to not include "Canary" in its GHA name to avoid confusion.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
