### PR TITLE
create parents of .cache directory

### DIFF
--- a/conda_index/index/sqlitecache.py
+++ b/conda_index/index/sqlitecache.py
@@ -113,7 +113,7 @@ class CondaIndexCache:
         self.channel_url = channel_url or str(channel_root)
 
         if not self.cache_dir.exists():
-            self.cache_dir.mkdir()
+            self.cache_dir.mkdir(parents=True)
 
         log.debug(
             f"CondaIndexCache channel_root={channel_root}, subdir={subdir} db_filename={self.db_filename} cache_is_brand_new={self.cache_is_brand_new}"

--- a/news/166-cache-mkdir-parents
+++ b/news/166-cache-mkdir-parents
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/166-cache-mkdir-parents
+++ b/news/166-cache-mkdir-parents
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* <news item>
+* Create parents when creating `<subdir>/.cache` (#166)
 
 ### Deprecations
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fix #166 

Checked by running python -m conda_index on a directory with noarch/ and verifying that all the other known subdirs are not created. We check subdirs exist before trying to make CondaIndexCache(), so the parents=True here does not create extra directories.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
