### PR TITLE
Add --no-current-repodata flag

### DIFF
--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -146,7 +146,7 @@ def cli(
         write_run_exports=run_exports,
         compact_json=compact,
         base_url=base_url,
-        current_repodata=current_repodata,
+        write_current_repodata=current_repodata,
     )
 
     current_index_versions = None

--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -92,23 +92,6 @@ from .. import yaml
         """,
 )
 @click.option(
-    "--save-fs-state/--no-save-fs-state",
-    help="""
-        Skip using listdir() to refresh the set of available packages. Used to
-        generate complete repodata.json from cache only when packages are not on
-        disk.
-        """,
-    default=False,
-    show_default=True,
-)
-@click.option(
-    "--upstream-stage",
-    help="""
-    Set to 'clone' to generate example repodata from conda-forge test database.
-    """,
-    default="fs",
-)
-@click.option(
     "--current-repodata/--no-current-repodata",
     help="""
         Skip generating current_repodata.json, a file containing only the newest
@@ -143,8 +126,6 @@ def cli(
     run_exports=False,
     compact=True,
     base_url=None,
-    save_fs_state=False,
-    upstream_stage="fs",
     current_repodata=False,
 ):
     logutil.configure()
@@ -165,24 +146,8 @@ def cli(
         write_run_exports=run_exports,
         compact_json=compact,
         base_url=base_url,
-        save_fs_state=save_fs_state,
         current_repodata=current_repodata,
     )
-
-    if save_fs_state is False:
-        # We call listdir() in save_fs_state, or its remote fs equivalent; then
-        # we call changed_packages(); but the changed_packages query against a
-        # remote filesystem is different than the one we need for a local
-        # filesystem. How about skipping the extract packages stage entirely by
-        # returning no changed packages? Might fail if we use
-        # threads/multiprocessing.
-        def no_changed_packages(self, *args):
-            return []
-
-        channel_index.cache_class.changed_packages = no_changed_packages
-
-    # XXX this patch doesn't stick when using multiprocessing
-    channel_index.cache_class.upstream_stage = upstream_stage
 
     current_index_versions = None
     if current_index_versions_file:

--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -98,7 +98,7 @@ from .. import yaml
         versions of all packages and their dependencies, only used by the
         classic solver.
         """,
-    default=False,
+    default=True,
     show_default=True,
 )
 @click.option("--threads", default=MAX_THREADS_DEFAULT, show_default=True)
@@ -126,7 +126,7 @@ def cli(
     run_exports=False,
     compact=True,
     base_url=None,
-    current_repodata=False,
+    current_repodata=True,
 ):
     logutil.configure()
     if verbose:

--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -91,6 +91,33 @@ from .. import yaml
         repodata_version=2 which is supported in conda 24.5.0 or later.
         """,
 )
+@click.option(
+    "--save-fs-state/--no-save-fs-state",
+    help="""
+        Skip using listdir() to refresh the set of available packages. Used to
+        generate complete repodata.json from cache only when packages are not on
+        disk.
+        """,
+    default=False,
+    show_default=True,
+)
+@click.option(
+    "--upstream-stage",
+    help="""
+    Set to 'clone' to generate example repodata from conda-forge test database.
+    """,
+    default="fs",
+)
+@click.option(
+    "--current-repodata/--no-current-repodata",
+    help="""
+        Skip generating current_repodata.json, a file containing only the newest
+        versions of all packages and their dependencies, only used by the
+        classic solver.
+        """,
+    default=False,
+    show_default=True,
+)
 @click.option("--threads", default=MAX_THREADS_DEFAULT, show_default=True)
 @click.option(
     "--verbose",
@@ -116,6 +143,9 @@ def cli(
     run_exports=False,
     compact=True,
     base_url=None,
+    save_fs_state=False,
+    upstream_stage="fs",
+    current_repodata=False,
 ):
     logutil.configure()
     if verbose:
@@ -135,7 +165,24 @@ def cli(
         write_run_exports=run_exports,
         compact_json=compact,
         base_url=base_url,
+        save_fs_state=save_fs_state,
+        current_repodata=current_repodata,
     )
+
+    if save_fs_state is False:
+        # We call listdir() in save_fs_state, or its remote fs equivalent; then
+        # we call changed_packages(); but the changed_packages query against a
+        # remote filesystem is different than the one we need for a local
+        # filesystem. How about skipping the extract packages stage entirely by
+        # returning no changed packages? Might fail if we use
+        # threads/multiprocessing.
+        def no_changed_packages(self, *args):
+            return []
+
+        channel_index.cache_class.changed_packages = no_changed_packages
+
+    # XXX this patch doesn't stick when using multiprocessing
+    channel_index.cache_class.upstream_stage = upstream_stage
 
     current_index_versions = None
     if current_index_versions_file:

--- a/conda_index/index/__init__.py
+++ b/conda_index/index/__init__.py
@@ -504,7 +504,7 @@ class ChannelIndex:
         channel_url: str | None = None,
         fs: MinimalFS | None = None,
         base_url: str | None = None,
-        current_repodata=False,
+        current_repodata=True,
     ):
         if threads is None:
             threads = MAX_THREADS_DEFAULT

--- a/conda_index/index/__init__.py
+++ b/conda_index/index/__init__.py
@@ -239,7 +239,7 @@ def _apply_instructions(subdir, repodata, instructions):
 
     for fn in instructions.get("revoke", ()):
         for key in ("packages", "packages.conda"):
-            if fn.endswith(CONDA_PACKAGE_EXTENSION_V1) and key == "packages.conda":
+            if key == "packages.conda" and fn.endswith(CONDA_PACKAGE_EXTENSION_V1):
                 fn = fn.replace(CONDA_PACKAGE_EXTENSION_V1, CONDA_PACKAGE_EXTENSION_V2)
             if fn in repodata[key]:
                 repodata[key][fn]["revoked"] = True
@@ -247,7 +247,7 @@ def _apply_instructions(subdir, repodata, instructions):
 
     for fn in instructions.get("remove", ()):
         for key in ("packages", "packages.conda"):
-            if fn.endswith(CONDA_PACKAGE_EXTENSION_V1) and key == "packages.conda":
+            if key == "packages.conda" and fn.endswith(CONDA_PACKAGE_EXTENSION_V1):
                 fn = fn.replace(CONDA_PACKAGE_EXTENSION_V1, CONDA_PACKAGE_EXTENSION_V2)
             popped = repodata[key].pop(fn, None)
             if popped:
@@ -504,6 +504,7 @@ class ChannelIndex:
         channel_url: str | None = None,
         fs: MinimalFS | None = None,
         base_url: str | None = None,
+        current_repodata=False,
     ):
         if threads is None:
             threads = MAX_THREADS_DEFAULT
@@ -530,6 +531,7 @@ class ChannelIndex:
         self.write_run_exports = write_run_exports
         self.compact_json = compact_json
         self.base_url = base_url
+        self.current_repodata = current_repodata
 
     def index(
         self,
@@ -638,21 +640,23 @@ class ChannelIndex:
 
         self._write_repodata(subdir, patched_repodata, REPODATA_JSON_FN)
 
-        log.info("%s Building current_repodata subset", subdir)
+        if self.current_repodata:
+            log.info("%s Building current_repodata subset", subdir)
 
-        log.debug("%s build current_repodata", subdir)
-        current_repodata = _build_current_repodata(
-            subdir, patched_repodata, pins=current_index_versions
-        )
+            current_repodata = _build_current_repodata(
+                subdir, patched_repodata, pins=current_index_versions
+            )
 
-        log.info("%s Writing current_repodata subset", subdir)
+            log.info("%s Writing current_repodata subset", subdir)
 
-        log.debug("%s write current_repodata", subdir)
-        self._write_repodata(
-            subdir,
-            current_repodata,
-            json_filename="current_repodata.json",
-        )
+            self._write_repodata(
+                subdir,
+                current_repodata,
+                json_filename="current_repodata.json",
+            )
+        else:
+            # XXX delete now-outdated current_repodata.json
+            pass
 
         if self.write_run_exports:
             log.info("%s Building run_exports data", subdir)

--- a/news/139-no-current-repodata
+++ b/news/139-no-current-repodata
@@ -1,0 +1,20 @@
+### Enhancements
+
+* Add `--current-repodata/--no-current-repodata` flags to control whether
+  `current_repodata.json` is generated. (#139)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1335,3 +1335,30 @@ def test_base_url(index_data):
 
     package_url = urllib.parse.urljoin(osx["info"]["base_url"], "package-1.0.conda")
     assert package_url == "https://example.org/somechannel/osx-64/package-1.0.conda"
+
+
+def test_write_current_repodata(index_data):
+    """
+    Test that we can skip current_repodata, and that it deletes the old one.
+    """
+    pkg_dir = Path(index_data, "packages")
+    pattern = "*/current_repodata.json*"
+
+    # compact json
+    channel_index = conda_index.index.ChannelIndex(
+        str(pkg_dir),
+        None,
+        write_bz2=True,
+        write_zst=True,
+        compact_json=True,
+        threads=1,
+    )
+
+    channel_index.index(None)
+
+    assert list(pkg_dir.glob(pattern))
+
+    channel_index.write_current_repodata = False
+    channel_index.index(None)
+
+    assert not list(pkg_dir.glob(pattern))


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

`current_repodata.json` is slow to generate and is only used by the classic solver. Add flag to skip it.

Fix #139 

We might be able to avoid "import conda" if we isolate the current_repodata code, since this is the only code that resolves dependencies.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
