### PR TITLE
Replace logger.warn w/ logger.warning

### DIFF
--- a/conda_index/index/__init__.py
+++ b/conda_index/index/__init__.py
@@ -125,7 +125,7 @@ def update_index(
     _, dirname = os.path.split(dir_path)
     if dirname in utils.DEFAULT_SUBDIRS:
         if warn:
-            log.warn(
+            log.warning(
                 "The update_index function has changed to index all subdirs at once.  You're pointing it at a single subdir.  "
                 "Please update your code to point it at the channel root, rather than a subdir. "
                 "Use -s=<subdir> to update a single subdir."
@@ -725,7 +725,7 @@ class ChannelIndex:
         else:
             self.subdirs = sorted(set(self._subdirs))
             if "noarch" not in self.subdirs:
-                log.warn("Indexing %s does not include 'noarch'", self.subdirs)
+                log.warning("Indexing %s does not include 'noarch'", self.subdirs)
         return self.subdirs
 
     def channeldata_path(self):
@@ -1108,7 +1108,7 @@ class ChannelIndex:
             elif path.endswith(CONDA_PACKAGE_EXTENSION_V2):
                 run_exports_conda_packages[path] = run_exports_data
             else:
-                log.warn("%s doesn't look like a conda package", path)
+                log.warning("%s doesn't look like a conda package", path)
 
         new_run_exports_data = {
             "packages": run_exports_packages,

--- a/conda_index/index/convert_cache.py
+++ b/conda_index/index/convert_cache.py
@@ -179,7 +179,7 @@ def extract_cache_filesystem(path):
                     with open(fullpath, "rb") as entry:
                         yield path_info, entry
                 except PermissionError as e:  # pragma: no cover
-                    log.warn("Permission error: %s %s", fullpath, e)
+                    log.warning("Permission error: %s %s", fullpath, e)
 
 
 # regex excludes arbitrary names
@@ -240,7 +240,7 @@ def convert_cache(conn, cache_generator):
                             },
                         )
                     except sqlite3.OperationalError as e:
-                        log.warn("SQL error. Not JSON? %s %s", match.groups(0), e)
+                        log.warning("SQL error. Not JSON? %s %s", match.groups(0), e)
 
                 elif match["kind"] == "icon":
                     conn.execute(
@@ -255,7 +255,7 @@ def convert_cache(conn, cache_generator):
                     )
 
                 else:  # pragma: no cover
-                    log.warn("Unhandled %r", match.groupdict())
+                    log.warning("Unhandled %r", match.groupdict())
 
 
 def merge_index_cache(channel_root, output_db="merged.db"):

--- a/conda_index/index/sqlitecache.py
+++ b/conda_index/index/sqlitecache.py
@@ -262,7 +262,7 @@ class CondaIndexCache:
                     wanted.remove(member.name)
                     reader = tar.extractfile(member)
                     if reader is None:
-                        log.warn(f"{abs_fn}/{member.name} was not a regular file")
+                        log.warning(f"{abs_fn}/{member.name} was not a regular file")
                         continue
                     have[member.name] = reader.read()
 
@@ -374,12 +374,12 @@ class CondaIndexCache:
                 {"upstream_stage": self.upstream_stage, "path": self.database_path(fn)},
             ).fetchone()[0]
         except TypeError:  # .fetchone() was None
-            log.warn("%s mtime not found in cache", fn)
+            log.warning("%s mtime not found in cache", fn)
             try:
                 mtime = os.stat(join(subdir_path, fn)).st_mtime
             except FileNotFoundError:
                 # don't call if it won't be found...
-                log.warn("%s not found in load_all_from_cache", fn)
+                log.warning("%s not found in load_all_from_cache", fn)
                 return {}
 
         # This method reads up pretty much all of the cached metadata, except
@@ -531,7 +531,7 @@ class CondaIndexCache:
             elif path.endswith(CONDA_PACKAGE_EXTENSION_V2):
                 new_repodata_conda_packages[path] = index_json
             else:
-                log.warn("%s doesn't look like a conda package", path)
+                log.warning("%s doesn't look like a conda package", path)
 
         return new_repodata_packages, new_repodata_conda_packages
 
@@ -618,4 +618,4 @@ def _clear_newline_chars(record, field_name):
                 )
 
             except TypeError:
-                log.warn("Could not _clear_newline_chars from field %s", field_name)
+                log.warning("Could not _clear_newline_chars from field %s", field_name)

--- a/conda_index/json2jlap.py
+++ b/conda_index/json2jlap.py
@@ -95,9 +95,9 @@ def json2jlap_one(cache: Path, repodata: Path, trim_high=0, trim_low=0):
 
         # inconvenient to add bytes size limit here; limit number of steps?
         if previous_digest == current_digest:
-            log.warn("Skip identical %s", repodata)
+            log.warning("Skip identical %s", repodata)
         elif len(jpatch.patch) > PATCH_STEPS_LIMIT:
-            log.warn("Skip large %s-step patch", len(jpatch.patch))
+            log.warning("Skip large %s-step patch", len(jpatch.patch))
         else:
             patches.add(
                 json.dumps(

--- a/conda_index/utils_build.py
+++ b/conda_index/utils_build.py
@@ -415,7 +415,7 @@ def copy_into(
                 src_folder = os.getcwd()
 
         if os.path.islink(src) and not os.path.exists(os.path.realpath(src)):
-            log.warn("path %s is a broken symlink - ignoring copy", src)
+            log.warning("path %s is a broken symlink - ignoring copy", src)
             return
 
         if not lock and locking:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This replaces use of the deprecated `.warn` method of logger objects with `.warning`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
