### PR TITLE
Correct testing per deprecation/removal in conda-build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,17 @@ Home = "https://github.com/conda/conda-index"
 [tool.pytest.ini_options]
 minversion = "7.0"
 testpaths = ["tests"]
+filterwarnings = [
+  # elevate conda's deprecated warning to an error
+  "error::PendingDeprecationWarning:conda",
+  "error::DeprecationWarning:conda",
+  # elevate conda-build's deprecated warning to an error
+  "error::PendingDeprecationWarning:conda_build",
+  "error::DeprecationWarning:conda_build",
+  # elevate conda-index's deprecated warning to an error
+  "error::PendingDeprecationWarning:conda_index",
+  "error::DeprecationWarning:conda_index",
+]
 
 [tool.coverage.run]
 concurrency = ["multiprocessing", "thread"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ from conda_build.config import (
     filename_hashing_default,
     ignore_verify_codes_default,
     no_rewrite_stdout_env_default,
-    noarch_python_build_age_default,
 )
 from conda_build.metadata import MetaData
 from conda_build.utils import check_call_env, copy_into, prepend_bin_path
@@ -108,7 +107,6 @@ def testing_config(testing_workdir):
         _src_cache_root=_src_cache_root_default,
         error_overlinking=boolify(error_overlinking_default),
         error_overdepending=boolify(error_overdepending_default),
-        noarch_python_build_age=noarch_python_build_age_default,
         enable_static=boolify(enable_static_default),
         no_rewrite_stdout_env=boolify(no_rewrite_stdout_env_default),
         ignore_verify_codes=ignore_verify_codes_default,
@@ -118,7 +116,6 @@ def testing_config(testing_workdir):
     assert result.no_rewrite_stdout_env is False
     assert result._src_cache_root is None
     assert result.src_cache_root == testing_workdir
-    assert result.noarch_python_build_age == 0
     return result
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

While working to migrate conda/conda-index to the new infrastructure sync workflow (see #178) realized that the tests were failing due to deprecated/removed code in conda-build.

To catch these deprecations (in both conda and conda-build) in the future we also elevate all deprecation warnings to errors.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
