### PR TITLE
Add mutual exclusive error handling

### DIFF
--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -115,7 +115,7 @@ from .. import yaml
     help="""
         Skip generating current_repodata.json, a file containing only the newest
         versions of all packages and their dependencies, only used by the
-        classic solver.
+        classic solver. Only works with --write-monolithic.
         """,
     default=True,
     show_default=True,

--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -220,7 +220,7 @@ def cli(
         if incompatible_args:
             args_str = ", ".join(incompatible_args)
             raise click.ClickException(
-                f"Arguments mutually exclusive: {args_str} require --write-monolithic (the default setting)."
+                f"Conflicting arguments: {args_str} require(s) --write-monolithic (the default setting)."
             )
 
     cache_kwargs = {}

--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -207,9 +207,8 @@ def cli(
     if output:
         output = os.path.expanduser(output)
 
-    # Check if repodata.json will be written at all
-    if not write_monolithic and not write_shards:
-        # When neither monolithic nor shards are written, repodata.json is not created
+    if not write_monolithic:
+        # --current-repodata, --run-exports, and --channeldata are only supported with --write-monolithic
         incompatible_args = []
         if current_repodata:
             incompatible_args.append("--current-repodata")
@@ -221,12 +220,8 @@ def cli(
         if incompatible_args:
             args_str = ", ".join(incompatible_args)
             raise click.ClickException(
-                f"Arguments mutually exclusive: {args_str} cannot be used when "
-                "both --no-write-monolithic and --no-write-shards are specified "
-                "(repodata.json is not written in this configuration)"
+                f"Arguments mutually exclusive: {args_str} require --write-monolithic (the default setting)."
             )
-    elif current_repodata and not write_monolithic:
-        raise click.ClickException("--current-repodata requires --write-monolithic")
 
     cache_kwargs = {}
 

--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -36,7 +36,7 @@ from .. import yaml
 )
 @click.option(
     "--channeldata/--no-channeldata",
-    help="Generate channeldata.json.",
+    help="Generate channeldata.json. Conflicts with --no-write-monolithic.",
     default=False,
     show_default=True,
 )
@@ -60,7 +60,7 @@ from .. import yaml
 )
 @click.option(
     "--run-exports/--no-run-exports",
-    help="Write run_exports.json.",
+    help="Write run_exports.json. Conflicts with --no-write-monolithic.",
     default=False,
     show_default=True,
 )
@@ -115,7 +115,7 @@ from .. import yaml
     help="""
         Skip generating current_repodata.json, a file containing only the newest
         versions of all packages and their dependencies, only used by the
-        classic solver.  Conflicts with --no-write-monolithic
+        classic solver.  Conflicts with --no-write-monolithic.
         """,
     default=True,
     show_default=True,

--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -207,7 +207,25 @@ def cli(
     if output:
         output = os.path.expanduser(output)
 
-    if current_repodata and not write_monolithic:
+    # Check if repodata.json will be written at all
+    if not write_monolithic and not write_shards:
+        # When neither monolithic nor shards are written, repodata.json is not created
+        incompatible_args = []
+        if current_repodata:
+            incompatible_args.append("--current-repodata")
+        if run_exports:
+            incompatible_args.append("--run-exports")
+        if channeldata:
+            incompatible_args.append("--channeldata")
+
+        if incompatible_args:
+            args_str = ", ".join(incompatible_args)
+            raise click.ClickException(
+                f"Arguments mutually exclusive: {args_str} cannot be used when "
+                "both --no-write-monolithic and --no-write-shards are specified "
+                "(repodata.json is not written in this configuration)"
+            )
+    elif current_repodata and not write_monolithic:
         raise click.ClickException("--current-repodata requires --write-monolithic")
 
     cache_kwargs = {}

--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -115,7 +115,7 @@ from .. import yaml
     help="""
         Skip generating current_repodata.json, a file containing only the newest
         versions of all packages and their dependencies, only used by the
-        classic solver. Only works with --write-monolithic.
+        classic solver.  Conflicts with --no-write-monolithic
         """,
     default=True,
     show_default=True,

--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -115,7 +115,7 @@ from .. import yaml
     help="""
         Skip generating current_repodata.json, a file containing only the newest
         versions of all packages and their dependencies, only used by the
-        classic solver.  Conflicts with --no-write-monolithic.
+        classic solver. Conflicts with --no-write-monolithic.
         """,
     default=True,
     show_default=True,

--- a/news/208-additional-confilct-flag-options
+++ b/news/208-additional-confilct-flag-options
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Show error when --no-write-monolithic is combined with --current-repodata, --run-exports, or --channeldata (#224)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,30 +53,13 @@ python:
     assert (tmp_path / "noarch" / "repodata.json").exists()
 
 
-def test_current_repodata_validation_with_write_shards_does_not_work(tmp_path):
-    """Test --current-repodata only works with --write-monolithic"""
-    runner = CliRunner()
-
-    # Test that --current-repodata still requires --write-monolithic when --write-shards is False
-    result = runner.invoke(cli, [
-        '--no-write-monolithic',
-        '--write-shards',
-        '--current-repodata',
-        str(tmp_path)
-    ])
-
-    assert result.exit_code != 0
-    assert "--current-repodata requires --write-monolithic" in result.output
-
-
 @pytest.mark.parametrize("cli_option", ["--current-repodata", "--run-exports", "--channeldata"])
-def test_mutual_exclusion_current_repodata(cli_option: str, tmp_path):
+def test_mutual_exclusion_mononlithic_repodata(cli_option: str, tmp_path):
     """Test that 'cli_option' is blocked when repodata.json is not written."""
     runner = CliRunner()
 
     result = runner.invoke(cli, [
         '--no-write-monolithic',
-        '--no-write-shards',
         cli_option,
         str(tmp_path)
     ])
@@ -84,4 +67,3 @@ def test_mutual_exclusion_current_repodata(cli_option: str, tmp_path):
     assert result.exit_code != 0
     assert "Arguments mutually exclusive" in result.output
     assert cli_option in result.output
-    assert "cannot be used when both --no-write-monolithic and --no-write-shards are specified" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,7 +71,7 @@ def test_current_repodata_validation_with_write_shards_does_not_work(tmp_path):
 
 @pytest.mark.parametrize("cli_option", ["--current-repodata", "--run-exports", "--channeldata"])
 def test_mutual_exclusion_current_repodata(cli_option: str, tmp_path):
-    """Test that --current-repodata is blocked when repodata.json is not written."""
+    """Test that 'cli_option' is blocked when repodata.json is not written."""
     runner = CliRunner()
 
     result = runner.invoke(cli, [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,5 +65,5 @@ def test_mutual_exclusion_mononlithic_repodata(cli_option: str, tmp_path):
     ])
 
     assert result.exit_code != 0
-    assert "Arguments mutually exclusive" in result.output
+    assert "Conflicting arguments" in result.output
     assert cli_option in result.output


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

- Added mutually exclusive logic that addresses bug #208 
  - Any option requiring repodata.json writes will cause an error if repodata.json is not written out
- Added tests

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-index/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-index/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-index/blob/main/CONTRIBUTING.md -->
