### PR TITLE
Exclude run_exports table from monolithic repodata in postgresql.

### DIFF
--- a/conda_index/postgres/cache.py
+++ b/conda_index/postgres/cache.py
@@ -291,38 +291,9 @@ class PsqlCache(BaseCondaIndexCache):
             record. Override to change the default hex to bytes hash
             conversions.
         """
-        index_json_table = model.Base.metadata.tables["index_json"]
-        stat_table = model.Base.metadata.tables["stat"]
-        run_exports_table = model.Base.metadata.tables["run_exports"]
-
         # not optimized for "desired" partial shards case but that's not
         # currently used.
-        query = (
-            select(
-                index_json_table.c.name,
-                index_json_table.c.path,
-                index_json_table.c.index_json,
-                run_exports_table.c.run_exports,
-            )
-            .select_from(
-                join(
-                    join(
-                        index_json_table,
-                        stat_table,
-                        index_json_table.c.path == stat_table.c.path,
-                    ),
-                    run_exports_table,
-                    index_json_table.c.path == run_exports_table.c.path,
-                    isouter=True,
-                )
-            )
-            .where(stat_table.c.stage == self.upstream_stage)
-            .where(stat_table.c.path.startswith(self.database_prefix, autoescape=True))
-            .order_by(
-                index_json_table.c.name,
-                index_json_table.c.path,
-            )
-        )
+        query = self._indexed_records_query(include_run_exports=True)
 
         connection: Connection
         with self.engine.begin() as connection:
@@ -353,26 +324,64 @@ class PsqlCache(BaseCondaIndexCache):
                 if not desired or name in desired:
                     yield shard
 
+    def _indexed_records_query(self, *, include_run_exports: bool):
+        """
+        Query package records from index_json + stat, optionally joining run_exports.
+        """
+        index_json_table = model.Base.metadata.tables["index_json"]
+        stat_table = model.Base.metadata.tables["stat"]
+
+        columns = [
+            index_json_table.c.name,
+            index_json_table.c.path,
+            index_json_table.c.index_json,
+        ]
+        from_clause = join(
+            index_json_table,
+            stat_table,
+            index_json_table.c.path == stat_table.c.path,
+        )
+
+        if include_run_exports:
+            run_exports_table = model.Base.metadata.tables["run_exports"]
+            columns.append(run_exports_table.c.run_exports)
+            from_clause = join(
+                from_clause,
+                run_exports_table,
+                index_json_table.c.path == run_exports_table.c.path,
+                isouter=True,
+            )
+
+        return (
+            select(*columns)
+            .select_from(from_clause)
+            .where(stat_table.c.stage == self.upstream_stage)
+            .where(stat_table.c.path.startswith(self.database_prefix, autoescape=True))
+            .order_by(index_json_table.c.name, index_json_table.c.path)
+        )
+
     def indexed_packages(self) -> IndexedPackages:
         """
         Return package sections from the cache.
         """
-        packages = {}
-        packages_conda = {}
-        packages_whl = {}
+        shard_dict = {"packages": {}, "packages.conda": {}, "packages.whl": {}}
 
-        def nopack_record(record):
-            return record
+        query = self._indexed_records_query(include_run_exports=False)
 
-        for shard in self.indexed_shards_2(pack_record=nopack_record):
-            packages.update(shard.packages)
-            packages_conda.update(shard.packages_conda)
-            packages_whl.update(shard.packages_whl)
+        connection: Connection
+        with self.engine.begin() as connection:
+            for _, path, index_json in connection.execute(query):
+                path = self.plain_path(path)
+                key = self.package_section_for_path(path)
+                if key is None:
+                    log.warning("%s has unsupported package extension", path)
+                    continue
+                shard_dict[key][path] = index_json
 
         return IndexedPackages(
-            packages=packages,
-            packages_conda=packages_conda,
-            packages_whl=packages_whl,
+            packages=shard_dict["packages"],
+            packages_conda=shard_dict["packages.conda"],
+            packages_whl=shard_dict["packages.whl"],
         )
 
     def load_all_from_cache(self, fn: str):

--- a/news/277-run-exports-json
+++ b/news/277-run-exports-json
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Separate sharded, monolithic queries for PostgreSQL (#277)

--- a/tests/test_psql.py
+++ b/tests/test_psql.py
@@ -330,6 +330,7 @@ def test_psql_skip_unknown_extension(tmp_path: Path):
     indexed_packages = cache.indexed_packages()
     assert len(indexed_packages.packages) == 1
     assert len(indexed_packages.packages_conda) == 1
+    assert "run_exports" not in indexed_packages.packages_conda["package-1.0.conda"]
 
 
 def test_psql_include_wheel_extension(tmp_path: Path):
@@ -385,10 +386,10 @@ def test_psql_run_exports(tmp_path: Path):
 
     # no index.json validation at this step, empty {} as record is passed on.
     connection.results_factory = lambda: [
-        DummyResult("package.conda", {}),
+        DummyResult("package.conda", {"weak": ["zlib"]}),
     ]
     run_exports = list(cache.run_exports())
-    assert run_exports == [("package.conda", {})]
+    assert run_exports == [("package.conda", {"weak": ["zlib"]})]
 
 
 def test_psql_load_all_from_cache_coverage(tmp_path: Path):

--- a/tests/test_sqlitecache.py
+++ b/tests/test_sqlitecache.py
@@ -74,6 +74,40 @@ def test_store_tolerates_null_md5(tmp_path):
     assert row["md5"] is None
 
 
+def test_indexed_packages_excludes_run_exports(tmp_path):
+    (tmp_path / "noarch").mkdir()
+    cache = CondaIndexCache(tmp_path, "noarch", upstream_stage="indexed")
+
+    cache.store(
+        "pkg-1.0-0.conda",
+        size=1234,
+        mtime=1000,
+        members={"info/run_exports.json": '{"weak": ["zlib"]}'},
+        index_json={
+            "name": "pkg",
+            "version": "1.0",
+            "build": "0",
+            "build_number": 0,
+            "subdir": "noarch",
+            "sha256": "a" * 64,
+            "md5": "b" * 32,
+            "size": 1234,
+        },
+    )
+
+    shards = list(cache.indexed_shards_2())
+    assert len(shards) == 1
+    assert shards[0].packages_conda["pkg-1.0-0.conda"]["run_exports"] == {
+        "weak": ["zlib"]
+    }
+
+    indexed_packages = cache.indexed_packages()
+    assert "run_exports" not in indexed_packages.packages_conda["pkg-1.0-0.conda"]
+
+    run_exports = list(cache.run_exports())
+    assert run_exports == [("pkg-1.0-0.conda", {"weak": ["zlib"]})]
+
+
 def test_store_fs_state_update_only_true(tmp_path):
     cache = CondaIndexCache(tmp_path, "noarch", update_only=True)
 


### PR DESCRIPTION


<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Also refactor sqlalchemy query; shards joins with run_exports, no shards does not.

Fix #277 

AI-assisted

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-index/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-index/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-index/blob/main/CONTRIBUTING.md -->
