### PR TITLE
Remove unused filelock dependency

### DIFF
--- a/conda_index/utils.py
+++ b/conda_index/utils.py
@@ -5,11 +5,9 @@ from concurrent.futures.thread import ThreadPoolExecutor
 from conda.base.constants import PLATFORM_DIRECTORIES as DEFAULT_SUBDIRS
 
 from .utils_build import ensure_list as ensure_list
-from .utils_build import get_lock as get_lock
 from .utils_build import merge_or_update_dict as merge_or_update_dict
 from .utils_build import move_with_fallback as move_with_fallback
 from .utils_build import move_with_fallback_nolock as move_with_fallback_nolock
-from .utils_build import try_acquire_locks as try_acquire_locks
 
 DEFAULT_SUBDIRS = DEFAULT_SUBDIRS
 
@@ -31,11 +29,9 @@ __all__ = [
     "checksums",
     "ensure_list",
     "file_contents_match",
-    "get_lock",
     "human_bytes",
     "merge_or_update_dict",
     "move_with_fallback",
-    "try_acquire_locks",
 ]
 CONDA_PACKAGE_EXTENSION_V2 = ".conda"
 CONDA_PACKAGE_EXTENSION_V1 = ".tar.bz2"

--- a/conda_index/utils_build.py
+++ b/conda_index/utils_build.py
@@ -2,17 +2,12 @@
 conda_build utils we need, without configuring logging as an import side effect.
 """
 
-import contextlib
-import hashlib
 import logging
 import os
 import shutil
 import subprocess
-import time
 from os import stat
 from os.path import isdir, isfile, islink
-
-import filelock
 
 log = logging.getLogger(__name__)
 
@@ -26,10 +21,6 @@ log = logging.getLogger(__name__)
 # )
 
 string_types = (str,)  # Python 3
-
-
-class LockError(Exception):
-    """Raised when we failed to acquire a lock."""
 
 
 def ensure_list(arg, include_dict=True):
@@ -113,44 +104,6 @@ def islist(arg, uniform=False, include_dict=True):
         return False
 
 
-# purpose here is that we want *one* lock per location on disk.  It can be
-# locked or unlocked at any time, but the lock within this process should all be
-# tied to the same tracking mechanism.
-_lock_folders = (os.path.expanduser(os.path.join("~", ".conda_build_locks")),)
-
-
-def get_lock(folder, timeout=900):
-    fl = None
-    try:
-        location = os.path.abspath(os.path.normpath(folder))
-    except OSError:
-        location = folder
-    b_location = location
-    if hasattr(b_location, "encode"):
-        b_location = b_location.encode()
-
-    # Hash the entire filename to avoid collisions.
-    lock_filename = hashlib.sha256(b_location).hexdigest()
-
-    for locks_dir in _lock_folders:
-        try:
-            if not os.path.isdir(locks_dir):
-                os.makedirs(locks_dir)
-            lock_file = os.path.join(locks_dir, lock_filename)
-            with open(lock_file, "w") as f:
-                f.write("")
-            fl = filelock.FileLock(lock_file, timeout)
-            break
-        except OSError:
-            continue
-    else:
-        raise RuntimeError(
-            "Could not write locks folder to either system location ({})"
-            "or user location ({}).  Aborting.".format(*_lock_folders)
-        )
-    return fl
-
-
 def _equivalent(base_value, value, path):
     equivalent = value == base_value
     if isinstance(value, string_types) and isinstance(base_value, string_types):
@@ -224,49 +177,6 @@ def merge_or_update_dict(
     return base
 
 
-@contextlib.contextmanager
-def try_acquire_locks(locks: list[filelock.FileLock], timeout):
-    """Try to acquire all locks.
-
-    If any lock can't be immediately acquired, free all locks.
-    If the timeout is reached withou acquiring all locks, free all locks and raise.
-
-    http://stackoverflow.com/questions/9814008/multiple-mutex-locking-strategies-and-why-libraries-dont-use-address-comparison
-    """
-    t = time.time()
-    while time.time() - t < timeout:
-        # Continuously try to acquire all locks.
-        # By passing a short timeout to each individual lock, we give other
-        # processes that might be trying to acquire the same locks (and may
-        # already hold some of them) a chance to the remaining locks - and
-        # hopefully subsequently release them.
-        try:
-            for lock in locks:
-                lock.acquire(timeout=0.1)
-        except filelock.Timeout:
-            # If we failed to acquire a lock, it is important to release all
-            # locks we may have already acquired, to avoid wedging multiple
-            # processes that try to acquire the same set of locks.
-            # That is, we want to avoid a situation where processes 1 and 2 try
-            # to acquire locks A and B, and proc 1 holds lock A while proc 2
-            # holds lock B.
-            for lock in locks:
-                lock.release()
-        else:
-            break
-    else:
-        # If we reach this point, we weren't able to acquire all locks within
-        # the specified timeout. We shouldn't be holding any locks anymore at
-        # this point, so we just raise an exception.
-        raise LockError("Failed to acquire all locks")
-
-    try:
-        yield
-    finally:
-        for lock in locks:
-            lock.release()
-
-
 # with each of these, we are copying less metadata.  This seems to be necessary
 #   to cope with some shared filesystems with some virtual machine setups.
 #  See https://github.com/conda/conda-build/issues/1426
@@ -330,9 +240,7 @@ def copytree(src, dst, symlinks=False, ignore=None, dry_run=False):
     return dst_lst
 
 
-def merge_tree(
-    src, dst, symlinks=False, timeout=900, lock=None, locking=True, clobber=False
-):
+def merge_tree(src, dst, symlinks=False, clobber=False, **_kwargs):
     """
     Merge src into dst recursively by copying all files from src into dst.
     Return a list of all files copied.
@@ -357,30 +265,10 @@ def merge_tree(
             "Can't merge {} into {}: file exists: {}".format(src, dst, existing[0])
         )
 
-    locks = []
-    if locking:
-        if not lock:
-            lock = get_lock(src, timeout=timeout)
-        locks = [lock]
-    with try_acquire_locks(locks, timeout):
-        copytree(src, dst, symlinks=symlinks)
+    copytree(src, dst, symlinks=symlinks)
 
 
-def merge_tree_nolock(
-    src, dst, symlinks=False, timeout=900, lock=None, locking=False, clobber=False
-):
-    """
-    merge_tree() with locking=False
-    """
-    return merge_tree(
-        src,
-        dst,
-        symlinks=symlinks,
-        timeout=timeout,
-        lock=None,
-        locking=locking,
-        clobber=clobber,
-    )
+merge_tree_nolock = merge_tree
 
 
 def get_prefix_replacement_paths(src, dst):
@@ -392,9 +280,7 @@ def get_prefix_replacement_paths(src, dst):
     return os.path.join(*ssplit), os.path.join(*dsplit)
 
 
-def copy_into(
-    src, dst, timeout=900, symlinks=False, lock=None, locking=True, clobber=False
-):
+def copy_into(src, dst, symlinks=False, clobber=False, **_kwargs):
     """Copy all the files and directories in src to the directory dst"""
 
     if symlinks and islink(src):
@@ -415,16 +301,7 @@ def copy_into(
         except:
             pass  # lchmod not available
     elif isdir(src):
-        merge_tree(
-            src,
-            dst,
-            symlinks,
-            timeout=timeout,
-            lock=lock,
-            locking=locking,
-            clobber=clobber,
-        )
-
+        merge_tree(src, dst, symlinks, clobber=clobber)
     else:
         if isdir(dst):
             dst_fn = os.path.join(dst, os.path.basename(src))
@@ -445,40 +322,21 @@ def copy_into(
             log.warning("path %s is a broken symlink - ignoring copy", src)
             return
 
-        if not lock and locking:
-            lock = get_lock(src_folder, timeout=timeout)
-        locks = [lock] if locking else []
-        with try_acquire_locks(locks, timeout):
-            # if intermediate folders not not exist create them
-            dst_folder = os.path.dirname(dst)
-            if dst_folder and not os.path.exists(dst_folder):
-                try:
-                    os.makedirs(dst_folder)
-                except OSError:
-                    pass
+        dst_folder = os.path.dirname(dst)
+        if dst_folder and not os.path.exists(dst_folder):
             try:
-                _copy_with_shell_fallback(src, dst_fn)
-            except shutil.Error:
-                log.debug(
-                    "skipping %s - already exists in %s", os.path.basename(src), dst
-                )
+                os.makedirs(dst_folder)
+            except OSError:
+                pass
+        try:
+            _copy_with_shell_fallback(src, dst_fn)
+        except shutil.Error:
+            log.debug(
+                "skipping %s - already exists in %s", os.path.basename(src), dst
+            )
 
 
-def copy_into_nolock(
-    src, dst, timeout=900, symlinks=False, lock=None, locking=False, clobber=False
-):
-    """
-    copy_into() with locking=False.
-    """
-    return copy_into(
-        src,
-        dst,
-        timeout=timeout,
-        symlinks=symlinks,
-        lock=None,
-        locking=locking,
-        clobber=clobber,
-    )
+copy_into_nolock = copy_into
 
 
 def move_with_fallback(src, dst):
@@ -494,17 +352,4 @@ def move_with_fallback(src, dst):
             )
 
 
-def move_with_fallback_nolock(src, dst):
-    """
-    Call shutil.move(src, dst) and try own implementation on PermissionError.
-    """
-    try:
-        shutil.move(src, dst)
-    except PermissionError:
-        try:
-            copy_into_nolock(src, dst)
-            os.unlink(src)
-        except PermissionError:
-            log.debug(
-                f"Failed to copy/remove path from {src} to {dst} due to permission error"
-            )
+move_with_fallback_nolock = move_with_fallback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     # Disabled due to conda not being available on PyPI
     # "conda",
     "conda-package-streaming >=0.12.0",
-    "filelock",
     "jinja2",
     "msgpack",
     "ruamel.yaml",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - click >=8
     - conda >=25
     - conda-package-streaming
-    - filelock
     - jinja2
     - msgpack-python >=1.0.2
     - ruamel.yaml


### PR DESCRIPTION
## Summary

- Remove `filelock` from `pyproject.toml` and `recipe/meta.yaml` dependencies
- Delete dead lock code (`get_lock`, `try_acquire_locks`, `LockError`) from `utils_build.py`
- Simplify `merge_tree`, `copy_into`, `move_with_fallback` by removing unused locking parameters
- Preserve `_nolock` aliases as references to the main functions for backward compatibility
- Clean up `utils.py` re-exports (`get_lock`, `try_acquire_locks` removed from `__all__`)

Closes #285

## Context

All callers (both in the main codebase and tests) exclusively use the `_nolock` function variants. No code path actually acquires file locks, making `filelock` a dead dependency. The `_nolock` aliases are kept as simple assignments (`copy_into_nolock = copy_into`) so any existing downstream code using them continues to work.

## Test plan

- [x] `python -m py_compile conda_index/utils_build.py` passes
- [x] `python -m py_compile conda_index/utils.py` passes
- [x] `copy_into_nolock` works correctly with file copy operations
- [x] All `_nolock` aliases resolve to the correct functions
- [ ] CI test suite passes