### PR TITLE
Explicitly close sqlite connections in ChannelIndex

### DIFF
--- a/conda_index/index/__init__.py
+++ b/conda_index/index/__init__.py
@@ -11,6 +11,7 @@ import multiprocessing
 import os
 import sys
 import time
+from contextlib import closing
 from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor
 from datetime import datetime, timezone
 from os.path import basename, getmtime, getsize, isfile, join
@@ -514,14 +515,14 @@ class ChannelIndex:
             def extract_wrapper(args: tuple):
                 # runs in thread
                 subdir, verbose, progress, subdir_path = args
-                cache = self.cache_for_subdir(subdir)
-                # exactly these packages (unless they are un-indexable) will
-                # be in the output repodata
-                if self.save_fs_state:
-                    cache.save_fs_state(subdir_path)
-                return self.extract_subdir_to_cache(
-                    subdir, verbose, progress, subdir_path, cache
-                )
+                with closing(self.cache_for_subdir(subdir)) as cache:
+                    # exactly these packages (unless they are un-indexable) will
+                    # be in the output repodata
+                    if self.save_fs_state:
+                        cache.save_fs_state(subdir_path)
+                    return self.extract_subdir_to_cache(
+                        subdir, verbose, progress, subdir_path, cache
+                    )
 
             # map() gives results in order passed, not in order of
             # completion. If using multiple threads, switch to
@@ -715,60 +716,65 @@ class ChannelIndex:
         Must call `extract_subdir_to_cache()` first or will be outdated.
         """
 
-        cache = self.cache_for_subdir(subdir)  # type: ignore
+        with closing(self.cache_for_subdir(subdir)) as cache:  # type: ignore
+            log.debug("Building repodata for %s/%s", self.channel_name, subdir)
 
-        log.debug("Building repodata for %s/%s", self.channel_name, subdir)
+            shards = {}
 
-        shards = {}
+            created_at = self.created_at
 
-        created_at = self.created_at
+            shards_index = {
+                "version": REPODATA_SHARDS_VERSION,
+                "info": {
+                    "base_url": "",  # pixi requires this key
+                    "shards_base_url": "",  # and this one
+                    "created_at": created_at,
+                    "subdir": subdir,
+                },
+                "shards": shards,
+            }
 
-        shards_index = {
-            "version": REPODATA_SHARDS_VERSION,
-            "info": {
-                "base_url": "",  # pixi requires this key
-                "shards_base_url": "",  # and this one
-                "created_at": created_at,
-                "subdir": subdir,
-            },
-            "shards": shards,
-        }
+            if self.base_url:
+                # per https://github.com/conda-incubator/ceps/blob/main/cep-15.md
+                shards_index["info"]["base_url"] = (
+                    f"{self.base_url.rstrip('/')}/{subdir}/"
+                )
 
-        if self.base_url:
-            # per https://github.com/conda-incubator/ceps/blob/main/cep-15.md
-            shards_index["info"]["base_url"] = f"{self.base_url.rstrip('/')}/{subdir}/"
+            # Higher compression levels are a waste of time for tiny gains on this
+            # collection of small objects.
+            compressor = zstandard.ZstdCompressor()
 
-        # Higher compression levels are a waste of time for tiny gains on this
-        # collection of small objects.
-        compressor = zstandard.ZstdCompressor()
+            (self.output_root / subdir).mkdir(parents=True, exist_ok=True)
 
-        (self.output_root / subdir).mkdir(parents=True, exist_ok=True)
+            v3_data = {
+                "tar.bz2": {},
+                "conda": {},
+                "whl": {},
+            }
 
-        v3_data = {
-            "tar.bz2": {},
-            "conda": {},
-            "whl": {},
-        }
+            for shard in cache.indexed_shards():
+                repodata_shard = self._indexed_shard_to_repodata(shard)
+                shard_bytes = compressor.compress(
+                    sqlitecache.packb_typed(repodata_shard)
+                )
+                shard_hash = hashlib.sha256(shard_bytes).digest()
+                output_path = (
+                    self.output_root / subdir / f"{shard_hash.hex()}.msgpack.zst"
+                )
+                if not output_path.exists():
+                    output_path.write_bytes(shard_bytes)
+                shards[shard.name] = shard_hash
 
-        for shard in cache.indexed_shards():
-            repodata_shard = self._indexed_shard_to_repodata(shard)
-            shard_bytes = compressor.compress(sqlitecache.packb_typed(repodata_shard))
-            shard_hash = hashlib.sha256(shard_bytes).digest()
-            output_path = self.output_root / subdir / f"{shard_hash.hex()}.msgpack.zst"
-            if not output_path.exists():
-                output_path.write_bytes(shard_bytes)
-            shards[shard.name] = shard_hash
+                if self.repodata_v3:
+                    for section, records in repodata_shard["v3"].items():
+                        v3_data[section].update(records)
 
             if self.repodata_v3:
-                for section, records in repodata_shard["v3"].items():
-                    v3_data[section].update(records)
+                shards_index["info"]["repodata_revisions"] = [
+                    self._make_repodata_revision_data(v3_data)
+                ]
 
-        if self.repodata_v3:
-            shards_index["info"]["repodata_revisions"] = [
-                self._make_repodata_revision_data(v3_data)
-            ]
-
-        return shards_index
+            return shards_index
 
     def index_subdir(self, subdir, verbose=False, progress=False):
         """
@@ -777,11 +783,10 @@ class ChannelIndex:
         Must call `extract_subdir_to_cache()` first or will be outdated.
         """
 
-        cache = self.cache_for_subdir(subdir)
+        with closing(self.cache_for_subdir(subdir)) as cache:
+            log.debug("Building repodata for %s/%s", self.channel_name, subdir)
 
-        log.debug("Building repodata for %s/%s", self.channel_name, subdir)
-
-        indexed_packages = cache.indexed_packages()
+            indexed_packages = cache.indexed_packages()
 
         new_repodata = {
             "packages": indexed_packages.packages,
@@ -1119,8 +1124,6 @@ class ChannelIndex:
         self._maybe_write(index_path, rendered_html)
 
     def _update_channeldata(self, channel_data, repodata, subdir):
-        cache = self.cache_for_subdir(subdir)
-
         legacy_packages = repodata["packages"]
         conda_packages = repodata["packages.conda"]
 
@@ -1169,77 +1172,86 @@ class ChannelIndex:
         if groups:
             fns, fn_dicts = zip(*groups)
 
-        load_func = cache.load_all_from_cache
-        with self.thread_executor_factory() as thread_executor:
-            for fn_dict, data in zip(fn_dicts, thread_executor.map(load_func, fns)):
-                # not reached when older channeldata.json matches
-                if data:
-                    data.update(fn_dict)
-                    name = data["name"]
-                    # existing record
-                    existing_record = package_data.get(name, {})
-                    data_v = data.get("version", "0")
-                    erec_v = existing_record.get("version", "0")
-                    # are timestamps already normalized to seconds?
-                    data_newer = VersionOrder(data_v) > VersionOrder(erec_v) or (
-                        data_v == erec_v
-                        and _make_seconds(data.get("timestamp", 0))
-                        > _make_seconds(existing_record.get("timestamp", 0))
-                    )
-
-                    package_data[name] = package_data.get(name, {})
-                    # keep newer value for these
-                    for k in (
-                        "description",
-                        "dev_url",
-                        "doc_url",
-                        "doc_source_url",
-                        "home",
-                        "license",
-                        "source_url",
-                        "source_git_url",
-                        "summary",
-                        "icon_url",
-                        "icon_hash",
-                        "tags",
-                        "identifiers",
-                        "keywords",
-                        "recipe_origin",
-                        "version",
-                    ):
-                        _replace_if_newer_and_present(
-                            package_data[name], data, existing_record, data_newer, k
+        with closing(self.cache_for_subdir(subdir)) as cache:
+            load_func = cache.load_all_from_cache
+            with self.thread_executor_factory() as thread_executor:
+                for fn_dict, data in zip(
+                    fn_dicts, thread_executor.map(load_func, fns)
+                ):
+                    # not reached when older channeldata.json matches
+                    if data:
+                        data.update(fn_dict)
+                        name = data["name"]
+                        # existing record
+                        existing_record = package_data.get(name, {})
+                        data_v = data.get("version", "0")
+                        erec_v = existing_record.get("version", "0")
+                        # are timestamps already normalized to seconds?
+                        data_newer = VersionOrder(data_v) > VersionOrder(
+                            erec_v
+                        ) or (
+                            data_v == erec_v
+                            and _make_seconds(data.get("timestamp", 0))
+                            > _make_seconds(existing_record.get("timestamp", 0))
                         )
 
-                    # keep any true value for these, since we don't distinguish subdirs
-                    for k in (
-                        "binary_prefix",
-                        "text_prefix",
-                        "activate.d",
-                        "deactivate.d",
-                        "pre_link",
-                        "post_link",
-                        "pre_unlink",
-                    ):
-                        package_data[name][k] = any(
-                            (data.get(k), existing_record.get(k))
-                        )
+                        package_data[name] = package_data.get(name, {})
+                        # keep newer value for these
+                        for k in (
+                            "description",
+                            "dev_url",
+                            "doc_url",
+                            "doc_source_url",
+                            "home",
+                            "license",
+                            "source_url",
+                            "source_git_url",
+                            "summary",
+                            "icon_url",
+                            "icon_hash",
+                            "tags",
+                            "identifiers",
+                            "keywords",
+                            "recipe_origin",
+                            "version",
+                        ):
+                            _replace_if_newer_and_present(
+                                package_data[name],
+                                data,
+                                existing_record,
+                                data_newer,
+                                k,
+                            )
 
-                    package_data[name]["subdirs"] = sorted(
-                        list(set(existing_record.get("subdirs", []) + [subdir]))
-                    )
-                    # keep one run_exports entry per version of the package, since these vary by version
-                    run_exports = existing_record.get("run_exports", {})
-                    exports_from_this_version = data.get("run_exports")
-                    if exports_from_this_version:
-                        run_exports[data_v] = data.get("run_exports")
-                    package_data[name]["run_exports"] = run_exports
-                    package_data[name]["timestamp"] = _make_seconds(
-                        max(
-                            data.get("timestamp", 0),
-                            channel_data.get(name, {}).get("timestamp", 0),
+                        # keep any true value for these, since we don't distinguish subdirs
+                        for k in (
+                            "binary_prefix",
+                            "text_prefix",
+                            "activate.d",
+                            "deactivate.d",
+                            "pre_link",
+                            "post_link",
+                            "pre_unlink",
+                        ):
+                            package_data[name][k] = any(
+                                (data.get(k), existing_record.get(k))
+                            )
+
+                        package_data[name]["subdirs"] = sorted(
+                            list(set(existing_record.get("subdirs", []) + [subdir]))
                         )
-                    )
+                        # keep one run_exports entry per version of the package, since these vary by version
+                        run_exports = existing_record.get("run_exports", {})
+                        exports_from_this_version = data.get("run_exports")
+                        if exports_from_this_version:
+                            run_exports[data_v] = data.get("run_exports")
+                        package_data[name]["run_exports"] = run_exports
+                        package_data[name]["timestamp"] = _make_seconds(
+                            max(
+                                data.get("timestamp", 0),
+                                channel_data.get(name, {}).get("timestamp", 0),
+                            )
+                        )
 
         channel_data.update(
             {
@@ -1278,23 +1290,21 @@ class ChannelIndex:
         """
         subdir_path = join(self.channel_root, subdir)
 
-        cache = self.cache_for_subdir(subdir)
-
         log.debug("Building run_exports for %s", subdir_path)
 
         run_exports_packages = {}
         run_exports_conda_packages = {}
 
-        # load cached packages
-        for row in cache.run_exports():
-            path, run_exports_data = row
-            run_exports_data = {"run_exports": run_exports_data or {}}
-            if path.endswith(CONDA_PACKAGE_EXTENSION_V1):
-                run_exports_packages[path] = run_exports_data
-            elif path.endswith(CONDA_PACKAGE_EXTENSION_V2):
-                run_exports_conda_packages[path] = run_exports_data
-            else:
-                log.warning("%s doesn't look like a conda package", path)
+        with closing(self.cache_for_subdir(subdir)) as cache:
+            for row in cache.run_exports():
+                path, run_exports_data = row
+                run_exports_data = {"run_exports": run_exports_data or {}}
+                if path.endswith(CONDA_PACKAGE_EXTENSION_V1):
+                    run_exports_packages[path] = run_exports_data
+                elif path.endswith(CONDA_PACKAGE_EXTENSION_V2):
+                    run_exports_conda_packages[path] = run_exports_data
+                else:
+                    log.warning("%s doesn't look like a conda package", path)
 
         new_run_exports_data = {
             "packages": run_exports_packages,

--- a/conda_index/index/__init__.py
+++ b/conda_index/index/__init__.py
@@ -11,7 +11,6 @@ import multiprocessing
 import os
 import sys
 import time
-from contextlib import closing
 from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor
 from datetime import datetime, timezone
 from os.path import basename, getmtime, getsize, isfile, join
@@ -515,7 +514,7 @@ class ChannelIndex:
             def extract_wrapper(args: tuple):
                 # runs in thread
                 subdir, verbose, progress, subdir_path = args
-                with closing(self.cache_for_subdir(subdir)) as cache:
+                with self.cache_for_subdir(subdir) as cache:
                     # exactly these packages (unless they are un-indexable) will
                     # be in the output repodata
                     if self.save_fs_state:
@@ -716,7 +715,7 @@ class ChannelIndex:
         Must call `extract_subdir_to_cache()` first or will be outdated.
         """
 
-        with closing(self.cache_for_subdir(subdir)) as cache:  # type: ignore
+        with self.cache_for_subdir(subdir) as cache:  # type: ignore
             log.debug("Building repodata for %s/%s", self.channel_name, subdir)
 
             shards = {}
@@ -783,7 +782,7 @@ class ChannelIndex:
         Must call `extract_subdir_to_cache()` first or will be outdated.
         """
 
-        with closing(self.cache_for_subdir(subdir)) as cache:
+        with self.cache_for_subdir(subdir) as cache:
             log.debug("Building repodata for %s/%s", self.channel_name, subdir)
 
             indexed_packages = cache.indexed_packages()
@@ -1172,12 +1171,10 @@ class ChannelIndex:
         if groups:
             fns, fn_dicts = zip(*groups)
 
-        with closing(self.cache_for_subdir(subdir)) as cache:
+        with self.cache_for_subdir(subdir) as cache:
             load_func = cache.load_all_from_cache
             with self.thread_executor_factory() as thread_executor:
-                for fn_dict, data in zip(
-                    fn_dicts, thread_executor.map(load_func, fns)
-                ):
+                for fn_dict, data in zip(fn_dicts, thread_executor.map(load_func, fns)):
                     # not reached when older channeldata.json matches
                     if data:
                         data.update(fn_dict)
@@ -1187,9 +1184,7 @@ class ChannelIndex:
                         data_v = data.get("version", "0")
                         erec_v = existing_record.get("version", "0")
                         # are timestamps already normalized to seconds?
-                        data_newer = VersionOrder(data_v) > VersionOrder(
-                            erec_v
-                        ) or (
+                        data_newer = VersionOrder(data_v) > VersionOrder(erec_v) or (
                             data_v == erec_v
                             and _make_seconds(data.get("timestamp", 0))
                             > _make_seconds(existing_record.get("timestamp", 0))
@@ -1295,7 +1290,7 @@ class ChannelIndex:
         run_exports_packages = {}
         run_exports_conda_packages = {}
 
-        with closing(self.cache_for_subdir(subdir)) as cache:
+        with self.cache_for_subdir(subdir) as cache:
             for row in cache.run_exports():
                 path, run_exports_data = row
                 run_exports_data = {"run_exports": run_exports_data or {}}

--- a/conda_index/index/cache.py
+++ b/conda_index/index/cache.py
@@ -24,8 +24,6 @@ from .fs import MinimalFS
 if TYPE_CHECKING:
     from typing import IO, Any, Iterator
 
-    from conda_index.index import ShardDict
-
     from .fs import FileInfo
 
 log = logging.getLogger(__name__)
@@ -176,6 +174,18 @@ class BaseCondaIndexCache(metaclass=abc.ABCMeta):
         """
         Remove and close any database connections.
         """
+
+    def __enter__(self) -> BaseCondaIndexCache:
+        """
+        Return self.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """
+        Call self.close()
+        """
+        self.close()
 
     @property
     def database_prefix(self) -> str:

--- a/news/236-close-sqlite-connections
+++ b/news/236-close-sqlite-connections
@@ -1,0 +1,23 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Explicitly close `sqlite3.Connection` objects opened by `CondaIndexCache`
+  inside `ChannelIndex` instead of relying on the garbage collector. This
+  avoids `ResourceWarning: unclosed database` on Python 3.13+ and releases
+  cache database files promptly so API consumers (e.g. `conda-build`) can
+  open them immediately after `update_index()` returns. (#236)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -33,7 +33,7 @@ here = os.path.dirname(__file__)
 TEST_SUBDIR = "osx-64"
 
 
-def download(url, local_path):
+def fake_download(url, local_path):
     # NOTE: The tests in this module used to download packages from the
     # conda-test channel. These packages are small and are now included.
     if not isdir(dirname(local_path)):
@@ -50,7 +50,7 @@ def test_index_on_single_subdir_1(testing_workdir):
         testing_workdir, "osx-64", "conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2"
     )
     test_package_url = "https://conda.anaconda.org/conda-test/osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2"
-    download(test_package_url, test_package_path)
+    fake_download(test_package_url, test_package_path)
 
     conda_index.index.update_index(
         testing_workdir, channel_name="test-channel", write_bz2=True, write_zst=True
@@ -177,7 +177,7 @@ def test_file_index_on_single_subdir_1(testing_workdir):
         testing_workdir, "osx-64", "conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2"
     )
     test_package_url = "https://conda.anaconda.org/conda-test/osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2"
-    download(test_package_url, test_package_path)
+    fake_download(test_package_url, test_package_path)
 
     conda_index.index.update_index(testing_workdir, channel_name="test-channel")
 
@@ -224,13 +224,13 @@ def test_file_index_on_single_subdir_1(testing_workdir):
     test_package_url = (
         "https://conda.anaconda.org/conda-test/osx-64/fly-2.5.2-0.tar.bz2"
     )
-    download(test_package_url, test_package_path)
+    fake_download(test_package_url, test_package_path)
 
     test_package_path = join(testing_workdir, "osx-64", "nano-2.4.1-0-tar.bz2")
     test_package_url = (
         "https://conda.anaconda.org/conda-test/osx-64/nano-2.4.1-0.tar.bz2"
     )
-    download(test_package_url, test_package_path)
+    fake_download(test_package_url, test_package_path)
 
     updated_packages = expected_repodata_json.get("packages")
 
@@ -304,13 +304,13 @@ def test_index_noarch_osx64_1(testing_workdir):
         testing_workdir, "osx-64", "conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2"
     )
     test_package_url = "https://conda.anaconda.org/conda-test/osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2"
-    download(test_package_url, test_package_path)
+    fake_download(test_package_url, test_package_path)
 
     test_package_path = join(
         testing_workdir, "noarch", "conda-index-pkg-a-1.0-pyhed9eced_1.tar.bz2"
     )
     test_package_url = "https://conda.anaconda.org/conda-test/noarch/conda-index-pkg-a-1.0-pyhed9eced_1.tar.bz2"
-    download(test_package_url, test_package_path)
+    fake_download(test_package_url, test_package_path)
 
     conda_index.index.update_index(testing_workdir, channel_name="test-channel")
 
@@ -819,7 +819,9 @@ def test_patch_instructions_with_missing_subdir(testing_workdir):
     url = "https://anaconda.org/conda-forge/{0}/20180828/download/noarch/{0}-20180828-0.tar.bz2".format(
         pkg
     )
-    patch_instructions = download(url, os.path.join(os.getcwd(), "patches.tar.bz2"))
+    patch_instructions = fake_download(
+        url, os.path.join(os.getcwd(), "patches.tar.bz2")
+    )
     conda_index.api.update_index(".", patch_generator=patch_instructions)
 
 
@@ -828,7 +830,7 @@ def test_stat_cache_used(testing_workdir, mocker):
         testing_workdir, "osx-64", "conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2"
     )
     test_package_url = "https://conda.anaconda.org/conda-test/osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2"
-    download(test_package_url, test_package_path)
+    fake_download(test_package_url, test_package_path)
     conda_index.index.update_index(testing_workdir, channel_name="test-channel")
 
     cph_extract = mocker.spy(conda_package_handling.api, "extract")
@@ -1098,7 +1100,7 @@ def test_index_clears_changed_packages(testing_workdir):
         testing_workdir, "osx-64", "conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2"
     )
     test_package_url = "https://conda.anaconda.org/conda-test/osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2"
-    download(test_package_url, test_package_path)
+    fake_download(test_package_url, test_package_path)
 
     conda_index.index.update_index(testing_workdir, channel_name="test-channel")
 
@@ -1111,7 +1113,7 @@ def test_index_clears_changed_packages(testing_workdir):
     import time
 
     time.sleep(1)  # ensure mtime is at least 1 second greater
-    download(test_package_url, test_package_path)
+    fake_download(test_package_url, test_package_path)
 
     with index_cache.db:  # force transaction
         # this function should also commit a transaction, even without `with
@@ -1523,7 +1525,7 @@ def test_update_index_closes_sqlite_connections(testing_workdir, monkeypatch):
         testing_workdir, "osx-64", "conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2"
     )
     test_package_url = "https://conda.anaconda.org/conda-test/osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2"
-    download(test_package_url, test_package_path)
+    fake_download(test_package_url, test_package_path)
 
     import sqlite3
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1507,7 +1507,7 @@ def test_index_format(tmp_path):
     }
 
 
-def test_update_index_closes_sqlite_connections(testing_workdir):
+def test_update_index_closes_sqlite_connections(testing_workdir, monkeypatch):
     """
     Regression test for https://github.com/conda/conda-index/issues/236.
 
@@ -1539,7 +1539,6 @@ def test_update_index_closes_sqlite_connections(testing_workdir):
             super().close()
 
     opened: list[_TrackingConnection] = []
-    real_connect = sqlitecache.common.connect
 
     def tracking_connect(dburi="cache.db"):
         conn = sqlite3.connect(dburi, uri=True, factory=_TrackingConnection)
@@ -1548,11 +1547,8 @@ def test_update_index_closes_sqlite_connections(testing_workdir):
         opened.append(conn)
         return conn
 
-    sqlitecache.common.connect = tracking_connect
-    try:
-        conda_index.index.update_index(testing_workdir, channel_name="test-channel")
-    finally:
-        sqlitecache.common.connect = real_connect
+    monkeypatch.setattr(sqlitecache.common, "connect", tracking_connect)
+    conda_index.index.update_index(testing_workdir, channel_name="test-channel")
 
     assert opened, "update_index did not open any sqlite connections"
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1505,3 +1505,59 @@ def test_index_format(tmp_path):
         "repodata_version": 1,
         "removed": [],
     }
+
+
+def test_update_index_closes_sqlite_connections(testing_workdir):
+    """
+    Regression test for https://github.com/conda/conda-index/issues/236.
+
+    ``update_index`` must explicitly close every sqlite3 connection it opens
+    via ``CondaIndexCache``. Previously the ``cache_for_subdir`` call sites in
+    ``ChannelIndex`` relied on Python's GC to finalize the connections, which
+    emits ``ResourceWarning: unclosed database`` on Python 3.13+ and can hold
+    on to file handles longer than expected.
+    """
+    from conda_index.index import sqlitecache
+
+    test_package_path = join(
+        testing_workdir, "osx-64", "conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2"
+    )
+    test_package_url = "https://conda.anaconda.org/conda-test/osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2"
+    download(test_package_url, test_package_path)
+
+    import sqlite3
+
+    class _TrackingConnection(sqlite3.Connection):
+        """Tracks whether ``close()`` was explicitly called."""
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.closed_explicitly = False
+
+        def close(self):
+            self.closed_explicitly = True
+            super().close()
+
+    opened: list[_TrackingConnection] = []
+    real_connect = sqlitecache.common.connect
+
+    def tracking_connect(dburi="cache.db"):
+        conn = sqlite3.connect(dburi, uri=True, factory=_TrackingConnection)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        opened.append(conn)
+        return conn
+
+    sqlitecache.common.connect = tracking_connect
+    try:
+        conda_index.index.update_index(testing_workdir, channel_name="test-channel")
+    finally:
+        sqlitecache.common.connect = real_connect
+
+    assert opened, "update_index did not open any sqlite connections"
+
+    leaked = [c for c in opened if not c.closed_explicitly]
+    assert not leaked, (
+        f"update_index left {len(leaked)} of {len(opened)} sqlite connection(s) "
+        "without an explicit close() call"
+    )


### PR DESCRIPTION
### Description

`ChannelIndex.cache_for_subdir()` returns a `CondaIndexCache` whose `db` attribute lazily opens an `sqlite3.Connection` on first access. Five callers in `ChannelIndex` (`extract_wrapper`, `index_subdir`, `index_subdir_shards`, `_update_channeldata`, `build_run_exports_data`) drop the cache reference without ever calling `close()`, so the connections stay open until the GC finalizes them.

This causes two issues:

1. On Python 3.13+ the sqlite3 module emits `ResourceWarning: unclosed database` for every connection finalized this way. conda-build CI on Python 3.14 hits this ~1900 times per run, see for example [this job](https://github.com/conda/conda-build/actions/runs/25104934835/job/73563713904?pr=5904).
2. The cache `.db` file can stay open longer than API consumers expect after `update_index()` returns, which is the original report in #236.

This PR wraps each `cache_for_subdir(subdir)` call site in `contextlib.closing(...)`, as suggested in #236.

A regression test (`test_update_index_closes_sqlite_connections`) subclasses `sqlite3.Connection` to track explicit `close()` calls and asserts every connection opened by `update_index()` is closed. The test fails on `main` and passes with this change.

Most of the diff line count is indentation from the new `with closing(...):` blocks; there are no behavior changes other than closing connections promptly.

Closes #236

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-index/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~ no documented behavior change.