### PR TITLE
Use argparse for fewer dependencies

### DIFF
--- a/conda_index/__main__.py
+++ b/conda_index/__main__.py
@@ -1,3 +1,6 @@
+import sys
+
 import conda_index.cli
 
-conda_index.cli.cli()
+if __name__ == "__main__":
+    conda_index.cli.cli(sys.argv[1:])

--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -2,225 +2,390 @@
 Updated command line interface for conda-index.
 """
 
+from __future__ import annotations
+
+import argparse
 import logging
 import os.path
+import sys
 from pathlib import Path
-
-import click
 
 from conda_index.index import MAX_THREADS_DEFAULT, ChannelIndex, logutil
 
 from .. import yaml
 
 
-@click.command(context_settings={"help_option_names": ["-h", "--help"]})
-@click.argument("dir")
-@click.option("--output", help="Output repodata to given directory.")
-@click.option(
-    "--subdir",
-    multiple=True,
-    default=None,
-    help="Subdir to index. Accepts multiple.",
-)
-@click.option(
-    "-n",
-    "--channel-name",
-    help="Customize the channel name listed in each channel's index.html.",
-)
-@click.option(
-    "--patch-generator",
-    required=False,
-    help="Path to Python file that outputs metadata patch instructions from its "
-    "_patch_repodata function or a .tar.bz2/.conda file which contains a "
-    "patch_instructions.json file for each subdir",
-)
-@click.option(
-    "--channeldata/--no-channeldata",
-    help="Generate channeldata.json. Conflicts with --no-write-monolithic.",
-    default=False,
-    show_default=True,
-)
-@click.option(
-    "--rss/--no-rss",
-    help="Write rss.xml (Only if --channeldata is enabled).",
-    default=True,
-    show_default=True,
-)
-@click.option(
-    "--bz2/--no-bz2",
-    help="Write repodata.json.bz2.",
-    default=False,
-    show_default=True,
-)
-@click.option(
-    "--zst/--no-zst",
-    help="Write repodata.json.zst.",
-    default=False,
-    show_default=True,
-)
-@click.option(
-    "--run-exports/--no-run-exports",
-    help="Write run_exports.json. Conflicts with --no-write-monolithic.",
-    default=False,
-    show_default=True,
-)
-@click.option(
-    "--compact/--no-compact",
-    help="Output JSON as one line, or pretty-printed.",
-    default=True,
-    show_default=True,
-)
-@click.option(
-    "--current-index-versions-file",
-    "-m",
-    help="""
-        YAML file containing name of package as key, and list of versions as values.  The current_index.json
-        will contain the newest from this series of versions.  For example:
+def _create_parser() -> argparse.ArgumentParser:
+    """Create and configure the argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Generate conda repository metadata (repodata.json) from a directory tree.",
+        add_help=True,
+    )
 
-        python:
-          - 3.8
-          - 3.9
+    # Positional argument
+    parser.add_argument(
+        "dir",
+        help="Directory to index",
+    )
 
-        will keep python 3.8.X and 3.9.Y in the current_index.json, instead of only the very latest python version.
-        """,
-)
-@click.option(
-    "--base-url",
-    help="""
-        If packages should be served separately from repodata.json, URL of the
-        directory tree holding packages. Generates repodata.json with
-        repodata_version=2 which is supported in conda 24.5.0 or later.
-        """,
-)
-@click.option(
-    "--update-cache/--no-update-cache",
-    help="""
-        Control whether listdir() is called to refresh the set of available
-        packages. Used to generate complete repodata.json from cache only when
-        packages are not on disk. (Experimental)
-        """,
-    default=True,
-    show_default=True,
-)
-@click.option(
-    "--update-only/--no-update-only",
-    help="""
-        Control whether missing files are deleted from repodata.json. Used to
-        add local files to repodata.json without having the complete set of
-        packages on disk. (Experimental)
-        """,
-    default=False,
-    show_default=True,
-)
-@click.option(
-    "--upstream-stage",
-    help="""
-    Set to 'clone' to generate example repodata from conda-forge test database.
-    (Experimental)
-    """,
-    default="fs",
-)
-@click.option(
-    "--current-repodata/--no-current-repodata",
-    help="""
-        Skip generating current_repodata.json, a file containing only the newest
-        versions of all packages and their dependencies, only used by the
-        classic solver. Conflicts with --no-write-monolithic.
-        """,
-    default=False,
-    show_default=True,
-)
-@click.option("--threads", default=MAX_THREADS_DEFAULT, show_default=True)
-@click.option(
-    "--verbose",
-    help="""
-        Enable debug logging.
-        """,
-    default=False,
-    is_flag=True,
-)
-@click.option(
-    "--write-monolithic/--no-write-monolithic",
-    help="""
-    Write repodata.json with all package metadata in a single file.
-    """,
-    default=True,
-    is_flag=True,
-)
-@click.option(
-    "--write-shards/--no-write-shards",
-    help="""
-        Write a repodata.msgpack.zst index and many smaller files per CEP-16.
-        (Experimental)
-        """,
-    default=False,
-    is_flag=True,
-)
-@click.option(
-    "--db",
-    help="""
-        Choose database backend. "sqlite3" (default) or "postgresql"
-        (Experimental)
-        """,
-    default="sqlite3",
-    type=click.Choice(["sqlite3", "postgresql"]),
-)
-@click.option(
-    "--db-url",
-    help="""
-        SQLAlchemy database URL when using --db=postgresql. Alternatively, use
-        the CONDA_INDEX_DBURL environment variable. (Experimental)
-        """,
-    default="postgresql:///conda_index",
-    show_default=True,
-    envvar="CONDA_INDEX_DBURL",
-)
-@click.option(
-    "--html-dependencies/--no-html-dependencies",
-    help="""
-        Include dependency popups in generated HTML index files.
-        May significantly increase file size for large repositories like
-        main or conda-forge.
-        """,
-    default=False,
-    show_default=True,
-)
-@click.option(
-    "--repodata-next/--no-repodata-next",
-    help="""
-        EXPERIMENTAL. Write CEP-XXXX v3 repodata layout with all package
-        records under a top-level v3 key.
-        """,
-    default=False,
-    show_default=True,
-)
-def cli(
-    dir,
-    patch_generator=None,
-    subdir=None,
-    output=None,
-    channeldata=False,
-    verbose=False,
-    threads=None,
-    current_index_versions_file=None,
-    channel_name=None,
-    bz2=False,
-    zst=False,
-    rss=False,
-    run_exports=False,
-    compact=True,
-    base_url=None,
-    update_cache=False,
-    upstream_stage="fs",
-    current_repodata=True,
-    write_monolithic=True,
-    write_shards=False,
-    db="sqlite3",
-    db_url="",
-    html_dependencies=False,
-    update_only=False,
-    repodata_next=False,
-):
+    # Output options
+    parser.add_argument(
+        "--output",
+        help="Output repodata to given directory.",
+        default=None,
+    )
+
+    parser.add_argument(
+        "--subdir",
+        action="append",
+        default=None,
+        help="Subdir to index. Accepts multiple.",
+    )
+
+    parser.add_argument(
+        "-n",
+        "--channel-name",
+        help="Customize the channel name listed in each channel's index.html.",
+        default=None,
+    )
+
+    # Patch generator
+    parser.add_argument(
+        "--patch-generator",
+        help="Path to Python file that outputs metadata patch instructions from its "
+        "_patch_repodata function or a .tar.bz2/.conda file which contains a "
+        "patch_instructions.json file for each subdir",
+        default=None,
+    )
+
+    # Boolean flags for channeldata and RSS
+    parser.add_argument(
+        "--channeldata",
+        action="store_true",
+        help="Generate channeldata.json. Conflicts with --no-write-monolithic.",
+    )
+
+    parser.add_argument(
+        "--no-channeldata",
+        action="store_false",
+        dest="channeldata",
+    )
+
+    parser.add_argument(
+        "--rss",
+        action="store_true",
+        default=True,
+        help="Write rss.xml (Only if --channeldata is enabled).",
+    )
+
+    parser.add_argument(
+        "--no-rss",
+        action="store_false",
+        dest="rss",
+    )
+
+    # Compression options
+    parser.add_argument(
+        "--bz2",
+        action="store_true",
+        help="Write repodata.json.bz2.",
+    )
+
+    parser.add_argument(
+        "--no-bz2",
+        action="store_false",
+        dest="bz2",
+    )
+
+    parser.add_argument(
+        "--zst",
+        action="store_true",
+        help="Write repodata.json.zst.",
+    )
+
+    parser.add_argument(
+        "--no-zst",
+        action="store_false",
+        dest="zst",
+    )
+
+    # Run exports and compact
+    parser.add_argument(
+        "--run-exports",
+        action="store_true",
+        help="Write run_exports.json. Conflicts with --no-write-monolithic.",
+    )
+
+    parser.add_argument(
+        "--no-run-exports",
+        action="store_false",
+        dest="run_exports",
+    )
+
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        default=True,
+        help="Output JSON as one line, or pretty-printed.",
+    )
+
+    parser.add_argument(
+        "--no-compact",
+        action="store_false",
+        dest="compact",
+    )
+
+    # Current index versions file
+    parser.add_argument(
+        "--current-index-versions-file",
+        "-m",
+        help="YAML file containing name of package as key, and list of versions as values. "
+        "The current_index.json will contain the newest from this series of versions. "
+        "For example: python: [3.8, 3.9] will keep python 3.8.X and 3.9.Y in the "
+        "current_index.json, instead of only the very latest python version.",
+        default=None,
+    )
+
+    # Base URL
+    parser.add_argument(
+        "--base-url",
+        help="If packages should be served separately from repodata.json, URL of the "
+        "directory tree holding packages. Generates repodata.json with "
+        "repodata_version=2 which is supported in conda 24.5.0 or later.",
+        default=None,
+    )
+
+    # Update cache and update only
+    parser.add_argument(
+        "--update-cache",
+        action="store_true",
+        default=True,
+        help="Control whether listdir() is called to refresh the set of available "
+        "packages. Used to generate complete repodata.json from cache only when "
+        "packages are not on disk. (Experimental)",
+    )
+
+    parser.add_argument(
+        "--no-update-cache",
+        action="store_false",
+        dest="update_cache",
+    )
+
+    parser.add_argument(
+        "--update-only",
+        action="store_true",
+        help="Control whether missing files are deleted from repodata.json. Used to "
+        "add local files to repodata.json without having the complete set of "
+        "packages on disk. (Experimental)",
+    )
+
+    parser.add_argument(
+        "--no-update-only",
+        action="store_false",
+        dest="update_only",
+    )
+
+    # Upstream stage
+    parser.add_argument(
+        "--upstream-stage",
+        help="Set to 'clone' to generate example repodata from conda-forge test database. "
+        "(Experimental)",
+        default="fs",
+    )
+
+    # Current repodata
+    parser.add_argument(
+        "--current-repodata",
+        action="store_true",
+        default=False,
+        help="Skip generating current_repodata.json, a file containing only the newest "
+        "versions of all packages and their dependencies, only used by the "
+        "classic solver. Conflicts with --no-write-monolithic.",
+    )
+
+    parser.add_argument(
+        "--no-current-repodata",
+        action="store_false",
+        dest="current_repodata",
+    )
+
+    # Threads and verbose
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=MAX_THREADS_DEFAULT,
+        help="Number of threads to use",
+    )
+
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging.",
+    )
+
+    # Write monolithic and write shards
+    parser.add_argument(
+        "--write-monolithic",
+        action="store_true",
+        default=True,
+        help="Write repodata.json with all package metadata in a single file.",
+    )
+
+    parser.add_argument(
+        "--no-write-monolithic",
+        action="store_false",
+        dest="write_monolithic",
+    )
+
+    parser.add_argument(
+        "--write-shards",
+        action="store_true",
+        help="Write a repodata.msgpack.zst index and many smaller files per CEP-16. "
+        "(Experimental)",
+    )
+
+    parser.add_argument(
+        "--no-write-shards",
+        action="store_false",
+        dest="write_shards",
+    )
+
+    # Database options
+    parser.add_argument(
+        "--db",
+        choices=["sqlite3", "postgresql"],
+        default="sqlite3",
+        help='Choose database backend. "sqlite3" (default) or "postgresql" (Experimental)',
+    )
+
+    parser.add_argument(
+        "--db-url",
+        default=os.environ.get("CONDA_INDEX_DBURL", "postgresql:///conda_index"),
+        help="SQLAlchemy database URL when using --db=postgresql. Alternatively, use "
+        "the CONDA_INDEX_DBURL environment variable. (Experimental)",
+    )
+
+    # HTML dependencies and repodata-next
+    parser.add_argument(
+        "--html-dependencies",
+        action="store_true",
+        help="Include dependency popups in generated HTML index files. "
+        "May significantly increase file size for large repositories like "
+        "main or conda-forge.",
+    )
+
+    parser.add_argument(
+        "--no-html-dependencies",
+        action="store_false",
+        dest="html_dependencies",
+    )
+
+    parser.add_argument(
+        "--repodata-next",
+        action="store_true",
+        help="EXPERIMENTAL. Write CEP-XXXX v3 repodata layout with all package "
+        "records under a top-level v3 key.",
+    )
+
+    parser.add_argument(
+        "--no-repodata-next",
+        action="store_false",
+        dest="repodata_next",
+    )
+
+    return parser
+
+
+def cli(args: list[str] | None = None) -> None:
+    """Main CLI entry point."""
+    parser = _create_parser()
+    parsed_args = parser.parse_args(args)
+
+    # Convert parsed arguments to the format expected by the rest of the code
+    dir_path = parsed_args.dir
+    patch_generator = parsed_args.patch_generator
+    subdir = parsed_args.subdir
+    output = parsed_args.output
+    channeldata = parsed_args.channeldata
+    verbose = parsed_args.verbose
+    threads = parsed_args.threads
+    current_index_versions_file = parsed_args.current_index_versions_file
+    channel_name = parsed_args.channel_name
+    bz2 = parsed_args.bz2
+    zst = parsed_args.zst
+    rss = parsed_args.rss
+    run_exports = parsed_args.run_exports
+    compact = parsed_args.compact
+    base_url = parsed_args.base_url
+    update_cache = parsed_args.update_cache
+    upstream_stage = parsed_args.upstream_stage
+    current_repodata = parsed_args.current_repodata
+    write_monolithic = parsed_args.write_monolithic
+    write_shards = parsed_args.write_shards
+    db = parsed_args.db
+    db_url = parsed_args.db_url
+    html_dependencies = parsed_args.html_dependencies
+    update_only = parsed_args.update_only
+    repodata_next = parsed_args.repodata_next
+
+    # Call the implementation function
+    _main_impl(
+        dir=dir_path,
+        patch_generator=patch_generator,
+        subdir=subdir,
+        output=output,
+        channeldata=channeldata,
+        verbose=verbose,
+        threads=threads,
+        current_index_versions_file=current_index_versions_file,
+        channel_name=channel_name,
+        bz2=bz2,
+        zst=zst,
+        rss=rss,
+        run_exports=run_exports,
+        compact=compact,
+        base_url=base_url,
+        update_cache=update_cache,
+        upstream_stage=upstream_stage,
+        current_repodata=current_repodata,
+        write_monolithic=write_monolithic,
+        write_shards=write_shards,
+        db=db,
+        db_url=db_url,
+        html_dependencies=html_dependencies,
+        update_only=update_only,
+        repodata_next=repodata_next,
+    )
+
+
+def _main_impl(
+    dir: str,
+    patch_generator: str | None = None,
+    subdir: list[str] | None = None,
+    output: str | None = None,
+    channeldata: bool = False,
+    verbose: bool = False,
+    threads: int | None = None,
+    current_index_versions_file: str | None = None,
+    channel_name: str | None = None,
+    bz2: bool = False,
+    zst: bool = False,
+    rss: bool = False,
+    run_exports: bool = False,
+    compact: bool = True,
+    base_url: str | None = None,
+    update_cache: bool = False,
+    upstream_stage: str = "fs",
+    current_repodata: bool = True,
+    write_monolithic: bool = True,
+    write_shards: bool = False,
+    db: str = "sqlite3",
+    db_url: str = "",
+    html_dependencies: bool = False,
+    update_only: bool = False,
+    repodata_next: bool = False,
+) -> None:
+    """Implementation of the main CLI logic."""
     logutil.configure()
     if verbose:
         logging.getLogger("conda_index.index").setLevel(logging.DEBUG)
@@ -240,9 +405,9 @@ def cli(
 
         if incompatible_args:
             args_str = ", ".join(incompatible_args)
-            raise click.ClickException(
-                f"Conflicting arguments: {args_str} require(s) --write-monolithic (the default setting)."
-            )
+            error_msg = f"Conflicting arguments: {args_str} require(s) --write-monolithic (the default setting)."
+            print(f"Error: {error_msg}", file=sys.stderr)
+            sys.exit(1)
 
     cache_kwargs = {}
 
@@ -253,7 +418,9 @@ def cli(
             cache_class = conda_index.postgres.cache.PsqlCache
             cache_kwargs["db_url"] = db_url
         except ImportError as e:
-            raise click.ClickException(f"Missing dependencies for postgresql: {e}")
+            error_msg = f"Missing dependencies for postgresql: {e}"
+            print(f"Error: {error_msg}", file=sys.stderr)
+            sys.exit(1)
     else:
         from conda_index.index.sqlitecache import CondaIndexCache
 

--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -32,13 +32,11 @@ def _create_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--output",
         help="Output repodata to given directory.",
-        default=None,
     )
 
     parser.add_argument(
         "--subdir",
         action="append",
-        default=None,
         help="Subdir to index. Accepts multiple.",
     )
 
@@ -46,7 +44,6 @@ def _create_parser() -> argparse.ArgumentParser:
         "-n",
         "--channel-name",
         help="Customize the channel name listed in each channel's index.html.",
-        default=None,
     )
 
     # Patch generator
@@ -55,7 +52,6 @@ def _create_parser() -> argparse.ArgumentParser:
         help="Path to Python file that outputs metadata patch instructions from its "
         "_patch_repodata function or a .tar.bz2/.conda file which contains a "
         "patch_instructions.json file for each subdir",
-        default=None,
     )
 
     # Boolean flags for channeldata and RSS
@@ -111,7 +107,6 @@ def _create_parser() -> argparse.ArgumentParser:
         "The current_index.json will contain the newest from this series of versions. "
         "For example: python: [3.8, 3.9] will keep python 3.8.X and 3.9.Y in the "
         "current_index.json, instead of only the very latest python version.",
-        default=None,
     )
 
     # Base URL
@@ -120,7 +115,6 @@ def _create_parser() -> argparse.ArgumentParser:
         help="If packages should be served separately from repodata.json, URL of the "
         "directory tree holding packages. Generates repodata.json with "
         "repodata_version=2 which is supported in conda 24.5.0 or later.",
-        default=None,
     )
 
     # Update cache and update only

--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -61,78 +61,46 @@ def _create_parser() -> argparse.ArgumentParser:
     # Boolean flags for channeldata and RSS
     parser.add_argument(
         "--channeldata",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="Generate channeldata.json. Conflicts with --no-write-monolithic.",
     )
 
     parser.add_argument(
-        "--no-channeldata",
-        action="store_false",
-        dest="channeldata",
-    )
-
-    parser.add_argument(
         "--rss",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=True,
         help="Write rss.xml (Only if --channeldata is enabled).",
-    )
-
-    parser.add_argument(
-        "--no-rss",
-        action="store_false",
-        dest="rss",
     )
 
     # Compression options
     parser.add_argument(
         "--bz2",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="Write repodata.json.bz2.",
     )
 
     parser.add_argument(
-        "--no-bz2",
-        action="store_false",
-        dest="bz2",
-    )
-
-    parser.add_argument(
         "--zst",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="Write repodata.json.zst.",
-    )
-
-    parser.add_argument(
-        "--no-zst",
-        action="store_false",
-        dest="zst",
     )
 
     # Run exports and compact
     parser.add_argument(
         "--run-exports",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="Write run_exports.json. Conflicts with --no-write-monolithic.",
     )
 
     parser.add_argument(
-        "--no-run-exports",
-        action="store_false",
-        dest="run_exports",
-    )
-
-    parser.add_argument(
         "--compact",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=True,
         help="Output JSON as one line, or pretty-printed.",
-    )
-
-    parser.add_argument(
-        "--no-compact",
-        action="store_false",
-        dest="compact",
     )
 
     # Current index versions file
@@ -158,7 +126,7 @@ def _create_parser() -> argparse.ArgumentParser:
     # Update cache and update only
     parser.add_argument(
         "--update-cache",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=True,
         help="Control whether listdir() is called to refresh the set of available "
         "packages. Used to generate complete repodata.json from cache only when "
@@ -166,23 +134,12 @@ def _create_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
-        "--no-update-cache",
-        action="store_false",
-        dest="update_cache",
-    )
-
-    parser.add_argument(
         "--update-only",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="Control whether missing files are deleted from repodata.json. Used to "
         "add local files to repodata.json without having the complete set of "
         "packages on disk. (Experimental)",
-    )
-
-    parser.add_argument(
-        "--no-update-only",
-        action="store_false",
-        dest="update_only",
     )
 
     # Upstream stage
@@ -196,17 +153,11 @@ def _create_parser() -> argparse.ArgumentParser:
     # Current repodata
     parser.add_argument(
         "--current-repodata",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=False,
         help="Skip generating current_repodata.json, a file containing only the newest "
         "versions of all packages and their dependencies, only used by the "
         "classic solver. Conflicts with --no-write-monolithic.",
-    )
-
-    parser.add_argument(
-        "--no-current-repodata",
-        action="store_false",
-        dest="current_repodata",
     )
 
     # Threads and verbose
@@ -226,28 +177,17 @@ def _create_parser() -> argparse.ArgumentParser:
     # Write monolithic and write shards
     parser.add_argument(
         "--write-monolithic",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=True,
         help="Write repodata.json with all package metadata in a single file.",
     )
 
     parser.add_argument(
-        "--no-write-monolithic",
-        action="store_false",
-        dest="write_monolithic",
-    )
-
-    parser.add_argument(
         "--write-shards",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="Write a repodata.msgpack.zst index and many smaller files per CEP-16. "
         "(Experimental)",
-    )
-
-    parser.add_argument(
-        "--no-write-shards",
-        action="store_false",
-        dest="write_shards",
     )
 
     # Database options
@@ -268,29 +208,19 @@ def _create_parser() -> argparse.ArgumentParser:
     # HTML dependencies and repodata-next
     parser.add_argument(
         "--html-dependencies",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="Include dependency popups in generated HTML index files. "
         "May significantly increase file size for large repositories like "
         "main or conda-forge.",
     )
 
     parser.add_argument(
-        "--no-html-dependencies",
-        action="store_false",
-        dest="html_dependencies",
-    )
-
-    parser.add_argument(
         "--repodata-next",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="EXPERIMENTAL. Write CEP-XXXX v3 repodata layout with all package "
         "records under a top-level v3 key.",
-    )
-
-    parser.add_argument(
-        "--no-repodata-next",
-        action="store_false",
-        dest="repodata_next",
     )
 
     return parser

--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -225,60 +225,32 @@ def cli(args: list[str] | None = None) -> None:
     parser = _create_parser()
     parsed_args = parser.parse_args(args)
 
-    # Convert parsed arguments to the format expected by the rest of the code
-    dir_path = parsed_args.dir
-    patch_generator = parsed_args.patch_generator
-    subdir = parsed_args.subdir
-    output = parsed_args.output
-    channeldata = parsed_args.channeldata
-    verbose = parsed_args.verbose
-    threads = parsed_args.threads
-    current_index_versions_file = parsed_args.current_index_versions_file
-    channel_name = parsed_args.channel_name
-    bz2 = parsed_args.bz2
-    zst = parsed_args.zst
-    rss = parsed_args.rss
-    run_exports = parsed_args.run_exports
-    compact = parsed_args.compact
-    base_url = parsed_args.base_url
-    update_cache = parsed_args.update_cache
-    upstream_stage = parsed_args.upstream_stage
-    current_repodata = parsed_args.current_repodata
-    write_monolithic = parsed_args.write_monolithic
-    write_shards = parsed_args.write_shards
-    db = parsed_args.db
-    db_url = parsed_args.db_url
-    html_dependencies = parsed_args.html_dependencies
-    update_only = parsed_args.update_only
-    repodata_next = parsed_args.repodata_next
-
-    # Call the implementation function
     _main_impl(
-        dir=dir_path,
-        patch_generator=patch_generator,
-        subdir=subdir,
-        output=output,
-        channeldata=channeldata,
-        verbose=verbose,
-        threads=threads,
-        current_index_versions_file=current_index_versions_file,
-        channel_name=channel_name,
-        bz2=bz2,
-        zst=zst,
-        rss=rss,
-        run_exports=run_exports,
-        compact=compact,
-        base_url=base_url,
-        update_cache=update_cache,
-        upstream_stage=upstream_stage,
-        current_repodata=current_repodata,
-        write_monolithic=write_monolithic,
-        write_shards=write_shards,
-        db=db,
-        db_url=db_url,
-        html_dependencies=html_dependencies,
-        update_only=update_only,
-        repodata_next=repodata_next,
+        dir=parsed_args.dir,
+        patch_generator=parsed_args.patch_generator,
+        subdir=parsed_args.subdir,
+        output=parsed_args.output,
+        channeldata=parsed_args.channeldata,
+        verbose=parsed_args.verbose,
+        threads=parsed_args.threads,
+        current_index_versions_file=parsed_args.current_index_versions_file,
+        channel_name=parsed_args.channel_name,
+        bz2=parsed_args.bz2,
+        zst=parsed_args.zst,
+        rss=parsed_args.rss,
+        run_exports=parsed_args.run_exports,
+        compact=parsed_args.compact,
+        base_url=parsed_args.base_url,
+        update_cache=parsed_args.update_cache,
+        upstream_stage=parsed_args.upstream_stage,
+        current_repodata=parsed_args.current_repodata,
+        write_monolithic=parsed_args.write_monolithic,
+        write_shards=parsed_args.write_shards,
+        db=parsed_args.db,
+        db_url=parsed_args.db_url,
+        html_dependencies=parsed_args.html_dependencies,
+        update_only=parsed_args.update_only,
+        repodata_next=parsed_args.repodata_next,
     )
 
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,8 @@
 # Command-line interface
 
 ```{eval-rst}
-.. click:: conda_index.cli:cli
+.. argparse::
+   :module: conda_index.cli
+   :func: _create_parser
    :prog: python -m conda_index
-   :nested: full
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ author = "conda"
 extensions = [
     "sphinx.ext.autodoc",
     "myst_parser",
-    "sphinx_click",
+    "sphinxarg.ext",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/news/288-use-argparse
+++ b/news/288-use-argparse
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Drop `click` dependency, use argparse. (#288)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ readme = "README.md"
 dynamic = ["version", "description"]
 requires-python = ">=3.10"
 dependencies = [
-    "click >=8",
     # Disabled due to conda not being available on PyPI
     # "conda",
     "conda-package-streaming >=0.12.0",
@@ -40,7 +39,7 @@ test = [
 docs = [
     "furo",
     "sphinx",
-    "sphinx-click",
+    "sphinx-argparse",
     "myst-parser",
     "mdit-py-plugins>=0.3.0",
 ]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - hatch-vcs >=0.2.0
   run:
     - python >=3.10
-    - click >=8
     - conda >=25
     - conda-package-streaming
     - filelock

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import sys
+from io import StringIO
+from unittest.mock import patch
+
 import pytest
-from click.testing import CliRunner
 
 from conda_index.cli import cli
 
@@ -9,7 +12,7 @@ from conda_index.cli import cli
 @pytest.mark.skip(reason="causes many other tests to fail")
 def test_cli(tmp_path):
     """
-    Coverage testing for the click cli.
+    Coverage testing for the argparse cli.
     """
 
     (tmp_path / "noarch").mkdir()  # makes valid channel
@@ -26,29 +29,30 @@ python:
 """
     )
 
-    runner = CliRunner()
-
     # fancy separate output directory run
-    result = runner.invoke(
-        cli,
-        [
-            f"--output={output_dir}",
-            f"--current-index-versions-file={current_index_versions}",
-            "--channeldata",
-            str(tmp_path),
-            "--rss",
-            "--bz2",
-            "--zst",
-            "--verbose",
-        ],
-    )
-    assert result.exit_code == 0, result.output
+    args = [
+        f"--output={output_dir}",
+        f"--current-index-versions-file={current_index_versions}",
+        "--channeldata",
+        str(tmp_path),
+        "--rss",
+        "--bz2",
+        "--zst",
+        "--verbose",
+    ]
+
+    try:
+        cli(args)
+        success = True
+    except SystemExit as e:
+        success = e.code == 0 or e.code is None
+
+    assert success, "CLI should exit successfully"
     assert (output_dir / "channeldata.json").exists()
-    # CliRunner isolation prevents checking logging.getLogger("conda.index").level == logging.DEBUG
 
     # plain run
     assert not (tmp_path / "noarch" / "repodata.json").exists()
-    runner.invoke(cli, [str(tmp_path)])
+    cli([str(tmp_path)])
     assert not (tmp_path / "channeldata.json").exists()
     assert (tmp_path / "noarch" / "repodata.json").exists()
 
@@ -58,10 +62,13 @@ python:
 )
 def test_mutual_exclusion_mononlithic_repodata(cli_option: str, tmp_path):
     """Test that 'cli_option' is blocked when repodata.json is not written."""
-    runner = CliRunner()
 
-    result = runner.invoke(cli, ["--no-write-monolithic", cli_option, str(tmp_path)])
+    # Capture stderr to check for error message
+    with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+        with pytest.raises(SystemExit) as exc_info:
+            cli(["--no-write-monolithic", cli_option, str(tmp_path)])
 
-    assert result.exit_code != 0
-    assert "Conflicting arguments" in result.output
-    assert cli_option in result.output
+        assert exc_info.value.code == 1
+        error_output = mock_stderr.getvalue()
+        assert "Conflicting arguments" in error_output
+        assert cli_option in error_output

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -105,8 +105,11 @@ def test_main():
     """
     Run module for coverage.
     """
+    # Test that CLI raises SystemExit when no arguments provided
+    from conda_index.cli import cli
+
     with pytest.raises(SystemExit):
-        import conda_index.__main__  # noqa: F401
+        cli([])
 
 
 def test_patch_instructions_coverage(tmp_path):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fix #288

click is great, but conda-index should have fewer dependencies; especially since more conda users will be using it as a conda-pypi dependency.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-index/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-index/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-index/blob/main/CONTRIBUTING.md -->
