### PR TITLE
Fix conda index plugin parser delegation

### DIFF
--- a/conda_index/cli/__init__.py
+++ b/conda_index/cli/__init__.py
@@ -15,11 +15,10 @@ from conda_index.index import MAX_THREADS_DEFAULT, ChannelIndex, logutil
 from .. import yaml
 
 
-def _create_parser() -> argparse.ArgumentParser:
-    """Create and configure the argument parser."""
-    parser = argparse.ArgumentParser(
-        description="Generate conda repository metadata (repodata.json) from a directory tree.",
-        add_help=True,
+def configure_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Configure the argument parser."""
+    parser.description = (
+        "Generate conda repository metadata (repodata.json) from a directory tree."
     )
 
     # Positional argument
@@ -220,11 +219,19 @@ def _create_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _create_parser() -> argparse.ArgumentParser:
+    """Create and configure the argument parser."""
+    return configure_parser(argparse.ArgumentParser(add_help=True))
+
+
 def cli(args: list[str] | None = None) -> None:
     """Main CLI entry point."""
     parser = _create_parser()
-    parsed_args = parser.parse_args(args)
+    run(parser.parse_args(args))
 
+
+def run(parsed_args: argparse.Namespace) -> None:
+    """Run the CLI from parsed arguments."""
     _main_impl(
         dir=parsed_args.dir,
         patch_generator=parsed_args.patch_generator,

--- a/conda_index/plugin.py
+++ b/conda_index/plugin.py
@@ -9,7 +9,13 @@ import conda.plugins.types
 def command(args):
     import conda_index.cli
 
-    return conda_index.cli.cli(prog_name="conda index", args=args)
+    return conda_index.cli.run(args)
+
+
+def configure_parser(parser):
+    import conda_index.cli
+
+    return conda_index.cli.configure_parser(parser)
 
 
 @conda.plugins.hookimpl
@@ -26,5 +32,8 @@ def conda_subcommands():
         pass
 
     yield conda.plugins.types.CondaSubcommand(
-        name="index", action=command, summary="Update package index metadata files."
+        name="index",
+        action=command,
+        summary="Update package index metadata files.",
+        configure_parser=configure_parser,
     )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import sys
+from argparse import Namespace
+from types import ModuleType
+
+import pytest
+
+import conda_index
+
+
+def import_plugin():
+    pytest.importorskip("conda.plugins.types")
+
+    import conda_index.plugin
+
+    return conda_index.plugin
+
+
+def test_command_delegates_to_cli(monkeypatch):
+    plugin = import_plugin()
+    cli = ModuleType("conda_index.cli")
+    calls = []
+    cli.run = calls.append
+    monkeypatch.setitem(sys.modules, "conda_index.cli", cli)
+    monkeypatch.setattr(conda_index, "cli", cli, raising=False)
+
+    args = Namespace(dir=".")
+    plugin.command(args)
+
+    assert calls == [args]
+
+
+def test_conda_subcommands_registers_index(monkeypatch):
+    plugin = import_plugin()
+    conda_build = ModuleType("conda_build")
+    conda_build.__version__ = "24.1.0"
+    monkeypatch.setitem(sys.modules, "conda_build", conda_build)
+
+    subcommands = list(plugin.conda_subcommands())
+
+    assert len(subcommands) == 1
+    assert subcommands[0].name == "index"
+    assert subcommands[0].action is plugin.command
+    assert subcommands[0].configure_parser is plugin.configure_parser


### PR DESCRIPTION
Closes #305.

### What changed

- Expose `conda_index.cli.configure_parser(parser)` so the existing CLI arguments can be installed into conda's plugin parser.
- Add `conda_index.cli.run(parsed_args)` for already-parsed plugin namespaces while keeping `cli(args)` for `python -m conda_index`.
- Register the `conda index` plugin with `configure_parser`, and delegate the parsed namespace to `run()`.
- Add plugin tests for subcommand registration and action delegation.

### Why

The plugin path passed an unsupported `prog_name=` keyword to `conda_index.cli.cli()`, so `conda index ...` failed before the CLI could run. Using `configure_parser` matches conda's plugin contract and keeps both entry points on the same parser setup.

### Validation

- `/Users/jezdez/.miniconda3/envs/conda-index-test/bin/python -m pytest tests/test_plugin.py -q`
- `/Users/jezdez/.miniconda3/envs/conda-index-test/bin/python -m pytest tests/test_cli.py tests/test_plugin.py -q -m "not needs_postgresql"`