### PR TITLE
Add CEP 47 indexed timestamps to repodata

### DIFF
--- a/conda_index/index/__init__.py
+++ b/conda_index/index/__init__.py
@@ -252,13 +252,20 @@ CHANNELDATA_FIELDS = (
 
 def _apply_instructions(subdir, repodata, instructions, new_pkg_fixes=None):
     repodata.setdefault("removed", [])
+
+    def apply_fixes(records, fixes):
+        for filename in records.keys() & fixes.keys():
+            fix = fixes[filename]
+            if "indexed_timestamp" in fix:
+                fix = {
+                    key: value
+                    for key, value in fix.items()
+                    if key != "indexed_timestamp"
+                }
+            utils.merge_or_update_dict(records[filename], fix, merge=False)
+
     # apply to .tar.bz2 packages
-    utils.merge_or_update_dict(
-        repodata.get("packages", {}),
-        instructions.get("packages", {}),
-        merge=False,
-        add_missing_keys=False,
-    )
+    apply_fixes(repodata.get("packages", {}), instructions.get("packages", {}))
 
     if new_pkg_fixes is None:
         # we could have totally separate instructions for .conda than .tar.bz2, but it's easier if we assume
@@ -269,18 +276,11 @@ def _apply_instructions(subdir, repodata, instructions, new_pkg_fixes=None):
         }
 
     # apply .tar.bz2 fixes to packages.conda
-    utils.merge_or_update_dict(
-        repodata.get("packages.conda", {}),
-        new_pkg_fixes,
-        merge=False,
-        add_missing_keys=False,
-    )
+    apply_fixes(repodata.get("packages.conda", {}), new_pkg_fixes)
     # apply .conda-only fixes to packages.conda
-    utils.merge_or_update_dict(
+    apply_fixes(
         repodata.get("packages.conda", {}),
         instructions.get("packages.conda", {}),
-        merge=False,
-        add_missing_keys=False,
     )
 
     for fn in instructions.get("revoke", ()):
@@ -472,9 +472,9 @@ class ChannelIndex:
 
         self.cache_kwargs = cache_kwargs
 
-        # Timestamp for this indexing run (consistent across all subdirs)
         now_dt = datetime.now(tz=timezone.utc)
         self.created_at = now_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        self.indexed_timestamp = int(now_dt.timestamp() * 1000)
 
     def cache_for_subdir(self, subdir):
         cache = self.cache_class(
@@ -486,6 +486,7 @@ class ChannelIndex:
             update_only=self.update_only,
             **self.cache_kwargs or {},
         )  # type: ignore
+        cache.indexed_timestamp = self.indexed_timestamp
         if cache.cache_is_brand_new:
             # guaranteed to be only thread doing this?
             cache.convert()
@@ -507,6 +508,10 @@ class ChannelIndex:
                 "ChannelIndex.index(verbose=...) is a no-op. Alter log levels for %s to control verbosity.",
                 __name__,
             )
+
+        now_dt = datetime.now(tz=timezone.utc)
+        self.created_at = now_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        self.indexed_timestamp = int(now_dt.timestamp() * 1000)
 
         subdirs = self.detect_subdirs()
 
@@ -894,7 +899,7 @@ class ChannelIndex:
         for section_records in revision_data.values():
             n_packages += len(section_records)
             for record in section_records.values():
-                timestamp = record.get("timestamp")
+                timestamp = record.get("indexed_timestamp")
                 if isinstance(timestamp, (int, float)):
                     timestamps.append(int(timestamp))
 
@@ -919,6 +924,7 @@ class ChannelIndex:
         Return name of subdir.
         """
         log.debug("%s find packages to extract", subdir)
+        cache.backfill_indexed_timestamps()
 
         # list so tqdm can show progress
         extract = [
@@ -971,7 +977,6 @@ class ChannelIndex:
             len(extract),
             utils.human_bytes(bytes_sec),
         )
-
         return subdir
 
     # region: channeldata

--- a/conda_index/index/cache.py
+++ b/conda_index/index/cache.py
@@ -11,6 +11,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -171,6 +172,8 @@ class BaseCondaIndexCache(metaclass=abc.ABCMeta):
         self.include_stages = include_stages
         self.package_extensions = package_extensions
         self.update_only = update_only
+        now = datetime.now(tz=timezone.utc)
+        self.indexed_timestamp = int(now.timestamp() * 1000)
 
         self.fs = fs or MinimalFS()
         self.channel_url = channel_url or str(channel_root)
@@ -186,6 +189,9 @@ class BaseCondaIndexCache(metaclass=abc.ABCMeta):
         """
         Convert filesystem cache to database.
         """
+
+    def backfill_indexed_timestamps(self) -> None:
+        """Persist timestamps for cached records that predate CEP 47."""
 
     def close(self) -> None:
         """

--- a/conda_index/index/convert_cache.py
+++ b/conda_index/index/convert_cache.py
@@ -53,6 +53,7 @@ TYPICAL_DIRECTORIES = {
 TABLE_NAMES = [
     "about",
     "icon",
+    "indexed_timestamp",
     "index_json",
     "post_install",
     "recipe_log",
@@ -78,6 +79,14 @@ def create(conn):
             path TEXT PRIMARY KEY, index_json BLOB,
             name AS (json_extract(index_json, '$.name')),
             sha256 AS (json_extract(index_json, '$.sha256'))
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS indexed_timestamp (
+            path TEXT PRIMARY KEY,
+            indexed_timestamp INTEGER NOT NULL
         )
         """
     )
@@ -309,6 +318,8 @@ def merge_index_cache(channel_root, output_db="merged.db"):
         cache_db = os.path.join(channel_root, subdir, ".cache", "cache.db")
         if not os.path.exists(cache_db):
             continue
+        with common.connect(cache_db) as source_db:
+            create(source_db)
         channel_prefix = f"{channel_name}/{subdir}/"
         log.info(
             f"Merge {os.path.relpath(cache_db, os.path.dirname(channel_root))} as {channel_prefix}"

--- a/conda_index/index/sqlitecache.py
+++ b/conda_index/index/sqlitecache.py
@@ -180,6 +180,49 @@ class CondaIndexCache(BaseCondaIndexCache):
             # prepare to be sent to other thread
             self.close()
 
+    def backfill_indexed_timestamps(self) -> None:
+        with self.db:
+            self.db.execute(
+                """
+                INSERT INTO indexed_timestamp (path, indexed_timestamp)
+                SELECT
+                    record.path,
+                    min(
+                        :indexed_timestamp,
+                        coalesce(
+                            CASE
+                                WHEN json_type(record.index_json, '$.timestamp') IN ('integer', 'real')
+                                THEN CAST(json_extract(record.index_json, '$.timestamp') AS INTEGER)
+                            END,
+                            (
+                                SELECT CAST(mtime * 1000 AS INTEGER)
+                                FROM stat
+                                WHERE stat.path = record.path
+                                    AND stat.stage IN (
+                                        :indexed_stage,
+                                        :upstream_stage
+                                    )
+                                ORDER BY stat.stage = :indexed_stage DESC
+                                LIMIT 1
+                            ),
+                            :indexed_timestamp
+                        )
+                    )
+                FROM index_json AS record
+                LEFT JOIN indexed_timestamp AS timestamp
+                    ON record.path = timestamp.path
+                WHERE record.path LIKE :path_like
+                    AND timestamp.path IS NULL
+                ON CONFLICT (path) DO NOTHING
+                """,
+                {
+                    "indexed_timestamp": self.indexed_timestamp,
+                    "indexed_stage": IndexedStages.INDEXED_STAGE.value,
+                    "upstream_stage": self.upstream_stage,
+                    "path_like": self.database_path_like,
+                },
+            )
+
     def store(
         self,
         fn: str,
@@ -219,6 +262,18 @@ class CondaIndexCache(BaseCondaIndexCache):
                     log.exception("table=%s parameters=%s", table, parameters)
                     # XXX delete from cache
                     raise
+
+            self.db.execute(
+                """
+                INSERT INTO indexed_timestamp (path, indexed_timestamp)
+                VALUES (:path, :indexed_timestamp)
+                ON CONFLICT (path) DO NOTHING
+                """,
+                {
+                    "path": database_path,
+                    "indexed_timestamp": self.indexed_timestamp,
+                },
+            )
 
             # sqlite json() function removes whitespace and ensures valid json
             self.db.execute(
@@ -371,7 +426,14 @@ class CondaIndexCache(BaseCondaIndexCache):
         # load cached packages
         for row in self.db.execute(
             f"""
-            SELECT path, index_json FROM stat JOIN index_json USING (path)
+            SELECT path, json_set(
+                index_json.index_json,
+                '$.indexed_timestamp',
+                indexed_timestamp.indexed_timestamp
+            ) AS index_json
+            FROM stat
+            JOIN index_json USING (path)
+            JOIN indexed_timestamp USING (path)
             WHERE stat.stage IN ({stages_placeholders})
             ORDER BY path
             """,
@@ -408,9 +470,16 @@ class CondaIndexCache(BaseCondaIndexCache):
 
         for name, rows in itertools.groupby(
             self.db.execute(
-                f"""SELECT index_json.name, index_json.path, index_json.index_json, run_exports.run_exports
+                f"""SELECT index_json.name, index_json.path,
+                    json_set(
+                        index_json.index_json,
+                        '$.indexed_timestamp',
+                        indexed_timestamp.indexed_timestamp
+                    ) AS index_json,
+                    run_exports.run_exports
                 FROM stat
                 JOIN index_json USING (path)
+                JOIN indexed_timestamp USING (path)
                 LEFT JOIN run_exports USING (path)
                 WHERE stat.stage IN ({stages_placeholders})
                 ORDER BY index_json.name, index_json.path""",

--- a/conda_index/postgres/cache.py
+++ b/conda_index/postgres/cache.py
@@ -126,6 +126,58 @@ class PsqlCache(BaseCondaIndexCache):
         # or call model.create(engine) here?
         log.warning(f"{self.__class__}.convert() is not implemented")
 
+    def backfill_indexed_timestamps(self) -> None:
+        insert_query = sqlalchemy.text(
+            """
+            INSERT INTO indexed_timestamp (path, indexed_timestamp)
+            SELECT
+                record.path,
+                LEAST(
+                    CAST(:indexed_timestamp AS BIGINT),
+                    COALESCE(
+                        CASE
+                            WHEN jsonb_typeof(record.index_json -> 'timestamp') = 'number'
+                                AND trunc(CAST(record.index_json ->> 'timestamp' AS NUMERIC))
+                                    BETWEEN -9223372036854775808
+                                    AND 9223372036854775807
+                            THEN CAST(
+                                trunc(CAST(record.index_json ->> 'timestamp' AS NUMERIC))
+                                AS BIGINT
+                            )
+                        END,
+                        (
+                            SELECT CAST(mtime AS BIGINT) * 1000
+                            FROM stat
+                            WHERE stat.path = record.path
+                                AND stat.stage IN (
+                                    :indexed_stage,
+                                    :upstream_stage
+                                )
+                            ORDER BY stat.stage = :indexed_stage DESC
+                            LIMIT 1
+                        ),
+                        CAST(:indexed_timestamp AS BIGINT)
+                    )
+                )
+            FROM index_json AS record
+            LEFT JOIN indexed_timestamp AS timestamp
+                ON record.path = timestamp.path
+            WHERE LEFT(record.path, LENGTH(:path_prefix)) = :path_prefix
+                AND timestamp.path IS NULL
+            ON CONFLICT (path) DO NOTHING
+            """
+        )
+        with self.engine.begin() as connection:
+            connection.execute(
+                insert_query,
+                {
+                    "indexed_timestamp": self.indexed_timestamp,
+                    "indexed_stage": "indexed",
+                    "upstream_stage": self.upstream_stage,
+                    "path_prefix": self.database_prefix,
+                },
+            )
+
     def store_stat_state(
         self, stage: str | None, listdir_stat: Iterable[dict[str, Any]]
     ):
@@ -173,6 +225,10 @@ class PsqlCache(BaseCondaIndexCache):
         database_path = self.database_path(fn)
         connection: Connection
         with self.engine.begin() as connection:
+            index_json_table = model.Base.metadata.tables["index_json"]
+            indexed_timestamp_table = model.Base.metadata.tables["indexed_timestamp"]
+            stat_table = model.Base.metadata.tables["stat"]
+
             for have_path in members:
                 table: str = PATH_TO_TABLE[have_path]
                 if table in TABLE_NO_CACHE or table == "index_json":
@@ -207,6 +263,16 @@ class PsqlCache(BaseCondaIndexCache):
                     log.exception("table=%s parameters=%s", table, parameters)
                     raise
 
+            timestamp_insert = insert(indexed_timestamp_table)
+            connection.execute(
+                timestamp_insert.values(
+                    path=database_path,
+                    indexed_timestamp=self.indexed_timestamp,
+                ).on_conflict_do_nothing(
+                    index_elements=[indexed_timestamp_table.c.path]
+                )
+            )
+
             table = "index_json"
             index_json_table = model.Base.metadata.tables[table]
             insert_obj = insert(index_json_table)
@@ -219,7 +285,6 @@ class PsqlCache(BaseCondaIndexCache):
                 )  # it will cast to jsonb automatically
             )
 
-            stat_table = model.Base.metadata.tables["stat"]
             values = {
                 "path": database_path,
                 "stage": "indexed",
@@ -333,20 +398,31 @@ class PsqlCache(BaseCondaIndexCache):
 
     def _indexed_records_query(self, *, include_run_exports: bool):
         """
-        Query package records from index_json + stat, optionally joining run_exports.
+        Query package records and server-controlled indexed timestamps.
         """
         index_json_table = model.Base.metadata.tables["index_json"]
+        indexed_timestamp_table = model.Base.metadata.tables["indexed_timestamp"]
         stat_table = model.Base.metadata.tables["stat"]
 
         columns = [
             index_json_table.c.name,
             index_json_table.c.path,
-            index_json_table.c.index_json,
+            index_json_table.c.index_json.op("||")(
+                sqlalchemy.func.jsonb_build_object(
+                    "indexed_timestamp",
+                    indexed_timestamp_table.c.indexed_timestamp,
+                )
+            ).label("index_json"),
         ]
         from_clause = join(
             index_json_table,
             stat_table,
             index_json_table.c.path == stat_table.c.path,
+        )
+        from_clause = join(
+            from_clause,
+            indexed_timestamp_table,
+            index_json_table.c.path == indexed_timestamp_table.c.path,
         )
 
         if include_run_exports:

--- a/conda_index/postgres/model.py
+++ b/conda_index/postgres/model.py
@@ -6,7 +6,16 @@ Used for psqlcache mode instead of low-dependencies sqlite mode.
 
 from __future__ import annotations
 
-from sqlalchemy import TEXT, Column, Computed, Integer, LargeBinary, Table, text
+from sqlalchemy import (
+    TEXT,
+    BigInteger,
+    Column,
+    Computed,
+    Integer,
+    LargeBinary,
+    Table,
+    text,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, mapped_column
 
@@ -15,6 +24,7 @@ from ..index.cache import IndexedStages
 TABLE_NAMES = {
     "about",
     "icon",
+    "indexed_timestamp",
     "index_json",
     "post_install",
     "recipe",
@@ -32,6 +42,8 @@ for table in TABLE_NAMES:
     columns = []
     if table == "icon":
         columns.append(Column("icon_png", LargeBinary))
+    elif table == "indexed_timestamp":
+        columns.append(Column(table, BigInteger, nullable=False))
     else:
         columns.append(Column(table, JSONB))  # or JSONB for postgresql?
     if table == "index_json":

--- a/docs/v3-repodata.md
+++ b/docs/v3-repodata.md
@@ -56,6 +56,25 @@ structure:
 }
 ```
 
+## Indexed timestamps
+
+Following [CEP 47](https://conda.org/learn/ceps/cep-0047/), every package
+record includes an `indexed_timestamp`. It is the Unix time in milliseconds
+when `conda-index` first added the artifact to its cache. The value is emitted
+in classic repodata, sharded repodata, and v3 repodata.
+
+`conda-index` assigns the current indexing time to new artifacts and ignores
+any `indexed_timestamp` embedded by a package builder. It persists the value in
+the index cache and preserves it across later indexing runs, including when an
+artifact's modification time changes.
+
+Cached records created before this field existed are backfilled once. The
+package `timestamp` is preferred, followed by the file modification time. The
+backfilled value is capped at the current indexing time and then persisted.
+
+For v3 repodata, `info.repodata_revisions.v3.oldest` and `newest` are the
+minimum and maximum `indexed_timestamp` values in that revision.
+
 ## Run-Exports in Shards (CEP 21)
 
 When using sharded repodata (`--write-shards`), each shard includes

--- a/news/341-indexed-timestamp
+++ b/news/341-indexed-timestamp
@@ -1,0 +1,7 @@
+### Enhancements
+
+* Add a persistent, server-controlled `indexed_timestamp` to package records. (#341)
+
+### Docs
+
+* Document indexed timestamps and v3 revision bounds. (#341)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -78,6 +78,7 @@ def test_cache(tmp_path):
     assert c.plain_path(db_path) == package
 
     c.convert()
+    c.backfill_indexed_timestamps()
     c.close()
 
     assert c.package_section_for_path("file.whl") == "packages.whl"

--- a/tests/test_demonstrate_wheel.py
+++ b/tests/test_demonstrate_wheel.py
@@ -54,10 +54,17 @@ def test_demonstrate_wheel(tmp_path: Path):
             }
 
     cache.store_md_state(listdir_like())
+    assert all(
+        "indexed_timestamp" not in record for record in input["v3"]["whl"].values()
+    )
 
     # packages from database
     packages = cache.indexed_packages()
     assert len(packages.packages_whl) == len(wheels)
+    assert all(
+        isinstance(record["indexed_timestamp"], int)
+        for record in packages.packages_whl.values()
+    )
 
     # repodata.json without repodata patches applied. Saved to
     # repodata_from_packages in full index() method, but in this case there are
@@ -78,4 +85,6 @@ def test_demonstrate_wheel(tmp_path: Path):
     output = json.loads((tmp_path / "noarch" / "repodata.json").read_text())
 
     # other details differ
+    for record in output["v3"]["whl"].values():
+        assert isinstance(record.pop("indexed_timestamp"), int)
     assert output["v3"]["whl"] == input["v3"]["whl"]

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import bz2
+import copy
 import json
 import os
 import re
@@ -8,12 +9,14 @@ import shutil
 import sys
 import tarfile
 import urllib.parse
+from datetime import datetime
 from logging import getLogger
 from os.path import isfile, join
 from pathlib import Path
 from shutil import rmtree
 
 import conda_package_handling.api
+import msgpack
 import pytest
 
 if sys.version_info >= (3, 14):  # pragma: no cover
@@ -44,6 +47,19 @@ here = os.path.dirname(__file__)
 
 # match ./index_hotfix_pkgs/<subdir>
 TEST_SUBDIR = "osx-64"
+
+
+def without_indexed_timestamps(repodata):
+    repodata = copy.deepcopy(repodata)
+    sections = [
+        repodata.get(section, {})
+        for section in ("packages", "packages.conda", "tar.bz2", "conda", "whl")
+    ]
+    sections.extend(repodata.get("v3", {}).values())
+    for section in sections:
+        for record in section.values():
+            assert isinstance(record.pop("indexed_timestamp"), int)
+    return repodata
 
 
 def test_index_on_single_subdir_1(testing_workdir):
@@ -119,8 +135,10 @@ def test_index_on_single_subdir_1(testing_workdir):
         "removed": [],
         "repodata_version": 1,
     }
-    assert actual_repodata_json == expected_repodata_json
-    assert actual_pkg_repodata_json == expected_repodata_json
+    assert without_indexed_timestamps(actual_repodata_json) == expected_repodata_json
+    assert (
+        without_indexed_timestamps(actual_pkg_repodata_json) == expected_repodata_json
+    )
 
     # #######################################
     # tests for full channel
@@ -217,8 +235,10 @@ def test_file_index_on_single_subdir_1(testing_workdir):
         "removed": [],
         "repodata_version": 1,
     }
-    assert actual_repodata_json == expected_repodata_json
-    assert actual_pkg_repodata_json == expected_repodata_json
+    assert without_indexed_timestamps(actual_repodata_json) == expected_repodata_json
+    assert (
+        without_indexed_timestamps(actual_pkg_repodata_json) == expected_repodata_json
+    )
 
     # download two packages here, put them both in the same subdir
     test_package_path = join(testing_workdir, "osx-64", "fly-2.5.2-0.tar.bz2")
@@ -244,8 +264,10 @@ def test_file_index_on_single_subdir_1(testing_workdir):
         actual_pkg_repodata_json = json.loads(fh.read())
         assert actual_pkg_repodata_json
 
-    assert actual_repodata_json == expected_repodata_json
-    assert actual_pkg_repodata_json == expected_repodata_json
+    assert without_indexed_timestamps(actual_repodata_json) == expected_repodata_json
+    assert (
+        without_indexed_timestamps(actual_pkg_repodata_json) == expected_repodata_json
+    )
 
     # #######################################
     # tests for full channel
@@ -361,8 +383,10 @@ def test_index_noarch_osx64_1(testing_workdir):
         "removed": [],
         "repodata_version": 1,
     }
-    assert actual_repodata_json == expected_repodata_json
-    assert actual_pkg_repodata_json == expected_repodata_json
+    assert without_indexed_timestamps(actual_repodata_json) == expected_repodata_json
+    assert (
+        without_indexed_timestamps(actual_pkg_repodata_json) == expected_repodata_json
+    )
 
     # #######################################
     # tests for full channel
@@ -568,6 +592,32 @@ def _patch_repodata(repodata, subdir):
             "package_has_been_revoked"
             not in pkg_list["revoke_test-1.0-0.tar.bz2"]["depends"]
         )
+
+
+def test_patch_cannot_change_indexed_timestamp():
+    filename = "pkg-1.0-0.tar.bz2"
+    legacy_filename = "legacy-1.0-0.tar.bz2"
+    repodata = {
+        "packages": {
+            filename: {"indexed_timestamp": 2000, "depends": ["old"]},
+            legacy_filename: {"depends": ["old"]},
+        },
+        "packages.conda": {},
+    }
+    instructions = {
+        "packages": {
+            filename: {"indexed_timestamp": 1, "depends": ["new"]},
+            legacy_filename: {"indexed_timestamp": 1, "depends": ["new"]},
+        }
+    }
+
+    conda_index.index._apply_instructions("noarch", repodata, instructions)
+
+    assert repodata["packages"][filename]["indexed_timestamp"] == 2000
+    assert repodata["packages"][filename]["depends"] == ["new"]
+    assert "indexed_timestamp" not in repodata["packages"][legacy_filename]
+    assert repodata["packages"][legacy_filename]["depends"] == ["new"]
+    assert instructions["packages"][filename]["indexed_timestamp"] == 1
 
 
 def test_channel_patch_instructions_json(testing_workdir):
@@ -776,6 +826,12 @@ def test_index_of_updated_package(testing_workdir):
     )
 
     with index_cache.db as db:
+        indexed_timestamps = {
+            row["path"]: row["indexed_timestamp"]
+            for row in db.execute(
+                "SELECT path, indexed_timestamp FROM indexed_timestamp"
+            )
+        }
         db.execute(f"UPDATE index_json SET index_json='{dummy_index_json}'")
         assert all(
             row["index_json"] == dummy_index_json
@@ -794,6 +850,12 @@ def test_index_of_updated_package(testing_workdir):
             row["index_json"] == dummy_index_json
             for row in db.execute("SELECT index_json FROM index_json")
         )
+        assert {
+            row["path"]: row["indexed_timestamp"]
+            for row in db.execute(
+                "SELECT path, indexed_timestamp FROM indexed_timestamp"
+            )
+        } == indexed_timestamps
         db.execute("UPDATE stat SET mtime = mtime-1")
         db.commit()
     index_cache.close()
@@ -906,7 +968,7 @@ def test_new_pkg_format_preferred(testing_workdir, mocker):
         "removed": [],
         "repodata_version": 1,
     }
-    assert actual_repodata_json == expected_repodata_json
+    assert without_indexed_timestamps(actual_repodata_json) == expected_repodata_json
 
     # if we clear the stat cache, we force a re-examination.  This
     # re-examination will load files from the cache.  This has been a source of
@@ -921,7 +983,7 @@ def test_new_pkg_format_preferred(testing_workdir, mocker):
     with open(join(testing_workdir, "osx-64", "repodata.json")) as fh:
         actual_repodata_json = json.loads(fh.read())
 
-    assert actual_repodata_json == expected_repodata_json
+    assert without_indexed_timestamps(actual_repodata_json) == expected_repodata_json
 
     # make sure .conda and .tar.bz2 exist in index.html
     index_html = Path(testing_workdir, "osx-64", "index.html").read_text()
@@ -1002,7 +1064,7 @@ def test_new_pkg_format_stat_cache_used(testing_workdir, mocker):
         "removed": [],
         "repodata_version": 1,
     }
-    assert actual_repodata_json == expected_repodata_json
+    assert without_indexed_timestamps(actual_repodata_json) == expected_repodata_json
 
 
 @pytest.mark.skipif(
@@ -1389,6 +1451,108 @@ def test_repodata_v3(index_data):
     assert noarch["v3"]["tar.bz2"] or noarch["v3"]["conda"]
 
 
+@pytest.mark.parametrize("repodata_v3", (False, True))
+def test_indexed_timestamp_outputs(index_data, repodata_v3, monkeypatch):
+    pkg_dir = Path(index_data, "packages")
+    indexed_timestamp = 2_000_000_000_000
+
+    class FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls.fromtimestamp(indexed_timestamp / 1000, tz=tz)
+
+    monkeypatch.setattr(conda_index.index, "datetime", FixedDatetime)
+    channel_index = conda_index.index.ChannelIndex(
+        pkg_dir,
+        None,
+        write_bz2=False,
+        write_zst=False,
+        compact_json=True,
+        threads=1,
+        write_shards=True,
+        repodata_v3=repodata_v3,
+    )
+    channel_index.index(None)
+
+    def records(repodata):
+        sections = (
+            repodata["v3"].values()
+            if repodata_v3
+            else (
+                repodata["packages"],
+                repodata["packages.conda"],
+            )
+        )
+        return [record for section in sections for record in section.values()]
+
+    noarch = json.loads((pkg_dir / "noarch" / "repodata.json").read_text())
+    assert records(noarch)
+    assert {record["indexed_timestamp"] for record in records(noarch)} == {
+        indexed_timestamp
+    }
+
+    shard_index = msgpack.loads(
+        zstd.decompress(
+            (pkg_dir / "noarch" / "repodata_shards.msgpack.zst").read_bytes()
+        )
+    )
+    shard_records = []
+    for shard_hash in shard_index["shards"].values():
+        shard = msgpack.loads(
+            zstd.decompress(
+                (pkg_dir / "noarch" / f"{shard_hash.hex()}.msgpack.zst").read_bytes()
+            )
+        )
+        shard_records.extend(records(shard))
+    assert shard_records
+    assert {record["indexed_timestamp"] for record in shard_records} == {
+        indexed_timestamp
+    }
+
+    if repodata_v3:
+        revision = noarch["info"]["repodata_revisions"]["v3"]
+        assert revision["oldest"] == indexed_timestamp
+        assert revision["newest"] == indexed_timestamp
+        shard_revision = shard_index["info"]["repodata_revisions"]["v3"]
+        assert shard_revision["oldest"] == indexed_timestamp
+        assert shard_revision["newest"] == indexed_timestamp
+
+
+def test_indexed_timestamp_refreshes_for_each_index_run(index_data, monkeypatch):
+    pkg_dir = Path(index_data, "packages")
+    channel_index = conda_index.index.ChannelIndex(
+        pkg_dir,
+        None,
+        subdirs=("noarch",),
+        write_bz2=False,
+        write_zst=False,
+        threads=1,
+    )
+    timestamps = iter((2_000_000, 2_000_000, 3_000_000, 3_000_000))
+
+    class FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls.fromtimestamp(next(timestamps) / 1000, tz=tz)
+
+    monkeypatch.setattr(conda_index.index, "datetime", FixedDatetime)
+    channel_index.index(None)
+    first_timestamp = channel_index.indexed_timestamp
+
+    source = pkg_dir / "noarch" / "run_exports_versions-1.0-he35c369_0.tar.bz2"
+    destination = pkg_dir / "noarch" / "new-package-1.0-0.tar.bz2"
+    shutil.copyfile(source, destination)
+    channel_index.index(None)
+
+    repodata = json.loads((pkg_dir / "noarch" / "repodata.json").read_text())
+    records = {
+        **repodata["packages"],
+        **repodata["packages.conda"],
+    }
+    assert records[source.name]["indexed_timestamp"] == first_timestamp
+    assert records[destination.name]["indexed_timestamp"] == 3_000_000
+
+
 def test_write_current_repodata(index_data):
     """
     Test that we can skip current_repodata, and that it deletes the old one.
@@ -1761,7 +1925,10 @@ def test_index_noarch_with_wheels(testing_workdir, cache_class, v3_repodata, req
         assert len(actual_repodata_json["v3"]["tar.bz2"]) == 1
         assert len(actual_repodata_json["v3"]["conda"]) == 0
         assert len(actual_repodata_json["v3"]["whl"]) == 1
-        assert actual_repodata_json["v3"] == expected_repodata_json_v3
+        assert (
+            without_indexed_timestamps(actual_repodata_json["v3"])
+            == expected_repodata_json_v3
+        )
     else:
         expected_repodata_json_v1 = {
             "info": {"subdir": "noarch"},
@@ -1786,7 +1953,10 @@ def test_index_noarch_with_wheels(testing_workdir, cache_class, v3_repodata, req
             "repodata_version": 1,
         }
         assert "v3" not in actual_repodata_json
-        assert actual_repodata_json == expected_repodata_json_v1
+        assert (
+            without_indexed_timestamps(actual_repodata_json)
+            == expected_repodata_json_v1
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_psql.py
+++ b/tests/test_psql.py
@@ -22,8 +22,14 @@ except ImportError:
 
 
 class MockResult:
+    def __init__(self, value=None):
+        self.value = value
+
     def first(self):
-        return None
+        return self.value
+
+    def scalar_one(self):
+        return self.value
 
 
 class MockConnection:
@@ -280,6 +286,7 @@ def test_psql_store_tolerates_null_md5(tmp_path: Path):
         "noarch",
         db_url="postgresql://example",
     )
+
     connection = MockConnection()
     cache.engine = MockEngine(connection)  # type: ignore
 
@@ -298,12 +305,211 @@ def test_psql_store_tolerates_null_md5(tmp_path: Path):
     )
 
     stat_insert = next(
-        (c for c in connection.calls if "stat" in str(c[0]).lower()),
+        (c for c in connection.calls if "insert into stat" in str(c[0]).lower()),
         None,
     )
     assert stat_insert is not None
     params = stat_insert[1] or {}
     assert params["md5"] is None
+
+
+def test_psql_store_preserves_index_json(tmp_path: Path):
+    cache = PsqlCache(
+        tmp_path,
+        "noarch",
+        db_url="postgresql://example",
+    )
+    cache.indexed_timestamp = 3000
+
+    connection = MockConnection()
+    cache.engine = MockEngine(connection)  # type: ignore
+    record = {
+        "name": "pkg",
+        "sha256": hashlib.sha256().hexdigest(),
+        "md5": hashlib.md5().hexdigest(),
+        "size": 1234,
+        "indexed_timestamp": 1,
+    }
+
+    cache.store("pkg-1.0-0.conda", 1234, 2, {}, record)
+
+    assert record["indexed_timestamp"] == 1
+    timestamp_insert = next(
+        statement
+        for statement, _params in connection.calls
+        if "insert into indexed_timestamp" in str(statement).lower()
+    )
+    compiled = timestamp_insert.compile()
+    assert 3000 in compiled.params.values()
+    assert "DO NOTHING" in str(timestamp_insert)
+
+
+@pytest.mark.needs_postgresql
+def test_psql_store_keeps_index_json_and_emits_indexed_timestamp(
+    tmp_path: Path, postgresql_database
+):
+    filename = "pkg-1.0-0.conda"
+    cache = PsqlCache(
+        tmp_path,
+        "noarch",
+        upstream_stage="indexed",
+        db_url=postgresql_database.url,
+    )
+    cache.indexed_timestamp = 2000
+    record = {
+        "name": "pkg",
+        "version": "1.0",
+        "sha256": hashlib.sha256().hexdigest(),
+        "md5": hashlib.md5().hexdigest(),
+        "size": 1234,
+        "indexed_timestamp": 1,
+    }
+
+    cache.store(filename, 1234, 1, {}, record)
+
+    index_json_table = model.Base.metadata.tables["index_json"]
+    indexed_timestamp_table = model.Base.metadata.tables["indexed_timestamp"]
+    database_path = cache.database_path(filename)
+    with cache.engine.begin() as connection:
+        stored = (
+            connection.execute(
+                index_json_table.select().where(
+                    index_json_table.c.path == database_path
+                )
+            )
+            .one()
+            .index_json
+        )
+        indexed_timestamp = (
+            connection.execute(
+                indexed_timestamp_table.select().where(
+                    indexed_timestamp_table.c.path == database_path
+                )
+            )
+            .one()
+            .indexed_timestamp
+        )
+
+    assert stored == record
+    assert indexed_timestamp == 2000
+    assert (
+        cache.indexed_packages().packages_conda[filename]["indexed_timestamp"] == 2000
+    )
+    assert (
+        next(cache.indexed_shards()).packages_conda[filename]["indexed_timestamp"]
+        == 2000
+    )
+
+    cache.indexed_timestamp = 3000
+    updated_record = {**record, "indexed_timestamp": 3000}
+    cache.store(filename, 1234, 2, {}, updated_record)
+
+    with cache.engine.begin() as connection:
+        stored = (
+            connection.execute(
+                index_json_table.select().where(
+                    index_json_table.c.path == database_path
+                )
+            )
+            .one()
+            .index_json
+        )
+        indexed_timestamp = (
+            connection.execute(
+                indexed_timestamp_table.select().where(
+                    indexed_timestamp_table.c.path == database_path
+                )
+            )
+            .one()
+            .indexed_timestamp
+        )
+
+    assert stored == updated_record
+    assert indexed_timestamp == 2000
+    assert (
+        cache.indexed_packages().packages_conda[filename]["indexed_timestamp"] == 2000
+    )
+
+
+@pytest.mark.needs_postgresql
+def test_psql_backfill_rejects_out_of_range_builder_timestamp(
+    tmp_path: Path, postgresql_database
+):
+    filename = "pkg-1.0-0.conda"
+    cache = PsqlCache(
+        tmp_path,
+        "noarch",
+        db_url=postgresql_database.url,
+    )
+    cache.indexed_timestamp = 3000
+    database_path = cache.database_path(filename)
+    index_json_table = model.Base.metadata.tables["index_json"]
+    stat_table = model.Base.metadata.tables["stat"]
+    indexed_timestamp_table = model.Base.metadata.tables["indexed_timestamp"]
+    with cache.engine.begin() as connection:
+        connection.execute(
+            index_json_table.insert().values(
+                path=database_path,
+                index_json={"name": "pkg", "timestamp": 1e100},
+            )
+        )
+        connection.execute(
+            stat_table.insert().values(
+                path=database_path,
+                stage="indexed",
+                mtime=2,
+                size=1,
+            )
+        )
+
+    cache.backfill_indexed_timestamps()
+
+    with cache.engine.begin() as connection:
+        indexed_timestamp = (
+            connection.execute(
+                indexed_timestamp_table.select().where(
+                    indexed_timestamp_table.c.path == database_path
+                )
+            )
+            .one()
+            .indexed_timestamp
+        )
+    assert indexed_timestamp == 2000
+
+
+def test_psql_backfill_indexed_timestamp(tmp_path: Path):
+    cache = PsqlCache(
+        tmp_path,
+        "noarch",
+        db_url="postgresql://example",
+    )
+    cache.indexed_timestamp = 3000
+    connection = MockConnection()
+    cache.engine = MockEngine(connection)  # type: ignore
+
+    cache.backfill_indexed_timestamps()
+
+    insert_query, params = connection.calls[0]
+    assert "insert into indexed_timestamp" in str(insert_query).lower()
+    assert len(connection.calls) == 1
+    assert "jsonb_set" not in str(insert_query)
+    assert params["indexed_timestamp"] == 3000
+    assert params["path_prefix"] == cache.database_prefix
+
+
+def test_psql_indexed_records_query_joins_indexed_timestamp(tmp_path: Path):
+    cache = PsqlCache(
+        tmp_path,
+        "noarch",
+        db_url="postgresql://example",
+    )
+
+    compiled = cache._indexed_records_query(include_run_exports=False).compile()
+
+    assert "JOIN indexed_timestamp" in str(compiled)
+    assert "jsonb_build_object" in str(compiled)
+    assert "||" in str(compiled)
+    assert "indexed_timestamp" in compiled.params.values()
 
 
 def test_psql_no_parse_icon_bad_package(tmp_path: Path):
@@ -316,6 +522,7 @@ def test_psql_no_parse_icon_bad_package(tmp_path: Path):
         "noarch",
         db_url="postgresql://example",
     )
+
     connection = MockConnection()
     cache.engine = MockEngine(connection)  # type: ignore
 
@@ -368,19 +575,36 @@ def test_psql_skip_unknown_extension(tmp_path: Path):
         last_call = connection.calls[-1]
         if len(last_call[0].columns) == 4:
             return [
-                DummyResultWithRunExports("package", "package.notconda", {}, {}),
-                DummyResultWithRunExports("package", "package-1.0.notconda", {}, {}),
                 DummyResultWithRunExports(
-                    "package", "package-1.0.conda", {}, {"weak": ["zlib"]}
+                    "package", "package.notconda", {"indexed_timestamp": 1000}, {}
                 ),
-                DummyResultWithRunExports("package", "package-1.0.tar.bz2", {}, {}),
+                DummyResultWithRunExports(
+                    "package", "package-1.0.notconda", {"indexed_timestamp": 1000}, {}
+                ),
+                DummyResultWithRunExports(
+                    "package",
+                    "package-1.0.conda",
+                    {"indexed_timestamp": 1000},
+                    {"weak": ["zlib"]},
+                ),
+                DummyResultWithRunExports(
+                    "package", "package-1.0.tar.bz2", {"indexed_timestamp": 1000}, {}
+                ),
             ]
         elif len(last_call[0].columns) == 3:
             return [
-                DummyResultWithoutRunExports("package", "package.notconda", {}),
-                DummyResultWithoutRunExports("package", "package-1.0.notconda", {}),
-                DummyResultWithoutRunExports("package", "package-1.0.conda", {}),
-                DummyResultWithoutRunExports("package", "package-1.0.tar.bz2", {}),
+                DummyResultWithoutRunExports(
+                    "package", "package.notconda", {"indexed_timestamp": 1000}
+                ),
+                DummyResultWithoutRunExports(
+                    "package", "package-1.0.notconda", {"indexed_timestamp": 1000}
+                ),
+                DummyResultWithoutRunExports(
+                    "package", "package-1.0.conda", {"indexed_timestamp": 1000}
+                ),
+                DummyResultWithoutRunExports(
+                    "package", "package-1.0.tar.bz2", {"indexed_timestamp": 1000}
+                ),
             ]
 
     # no index.json validation at this step, empty {} as record is passed on.
@@ -394,11 +618,16 @@ def test_psql_skip_unknown_extension(tmp_path: Path):
     assert shard.packages_conda["package-1.0.conda"]["run_exports"] == {
         "weak": ["zlib"]
     }
+    assert shard.packages_conda["package-1.0.conda"]["indexed_timestamp"] == 1000
 
     indexed_packages = cache.indexed_packages()
     assert len(indexed_packages.packages) == 1
     assert len(indexed_packages.packages_conda) == 1
     assert "run_exports" not in indexed_packages.packages_conda["package-1.0.conda"]
+    assert (
+        indexed_packages.packages_conda["package-1.0.conda"]["indexed_timestamp"]
+        == 1000
+    )
 
 
 def test_psql_include_wheel_extension(tmp_path: Path):

--- a/tests/test_sqlitecache.py
+++ b/tests/test_sqlitecache.py
@@ -13,6 +13,7 @@ import pytest
 
 from conda_index.index.cache import (
     IndexedStages,
+    UpstreamStages,
     _cache_post_install_details,
     _cache_recipe,
 )
@@ -92,6 +93,153 @@ def test_store_tolerates_null_md5(tmp_path):
     assert row["path"] == "pkg-1.0-py3_none.whl"
     assert row["sha256"] == "a" * 64
     assert row["md5"] is None
+
+
+def test_store_preserves_index_json_and_indexed_timestamp(tmp_path):
+    (tmp_path / "noarch").mkdir()
+    filename = "pkg-1.0-0.conda"
+    record = {
+        "name": "pkg",
+        "version": "1.0",
+        "sha256": "a" * 64,
+        "md5": "b" * 32,
+        "size": 1234,
+        "timestamp": 1000,
+        "indexed_timestamp": 1,
+    }
+
+    cache = CondaIndexCache(
+        tmp_path, "noarch", upstream_stage=IndexedStages.INDEXED_STAGE.value
+    )
+    cache.indexed_timestamp = 2000
+    cache.store(filename, 1234, 1, {}, record)
+    stored = json.loads(
+        cache.db.execute(
+            "SELECT index_json FROM index_json WHERE path = ?", (filename,)
+        ).fetchone()[0]
+    )
+    assert stored == record
+    assert (
+        cache.db.execute(
+            "SELECT indexed_timestamp FROM indexed_timestamp WHERE path = ?",
+            (filename,),
+        ).fetchone()[0]
+        == 2000
+    )
+    assert (
+        cache.indexed_packages().packages_conda[filename]["indexed_timestamp"] == 2000
+    )
+    assert (
+        next(cache.indexed_shards()).packages_conda[filename]["indexed_timestamp"]
+        == 2000
+    )
+    cache.close()
+
+    cache = CondaIndexCache(
+        tmp_path, "noarch", upstream_stage=IndexedStages.INDEXED_STAGE.value
+    )
+    cache.indexed_timestamp = 3000
+    updated_record = {**record, "indexed_timestamp": 3000}
+    cache.store(filename, 1234, 2, {}, updated_record)
+    stored = json.loads(
+        cache.db.execute(
+            "SELECT index_json FROM index_json WHERE path = ?", (filename,)
+        ).fetchone()[0]
+    )
+    assert stored == updated_record
+    assert (
+        cache.db.execute(
+            "SELECT indexed_timestamp FROM indexed_timestamp WHERE path = ?",
+            (filename,),
+        ).fetchone()[0]
+        == 2000
+    )
+    assert (
+        cache.indexed_packages().packages_conda[filename]["indexed_timestamp"] == 2000
+    )
+
+
+def test_backfill_indexed_timestamp_is_stable(tmp_path):
+    (tmp_path / "noarch").mkdir()
+    cache = CondaIndexCache(
+        tmp_path,
+        "noarch",
+        include_stages=[IndexedStages.INDEXED_STAGE.value],
+    )
+    cache.indexed_timestamp = 3000
+    records = {
+        "from-builder-1.0-0.conda": {
+            "name": "from-builder",
+            "timestamp": 1500,
+            "indexed_timestamp": 1,
+        },
+        "from-mtime-1.0-0.conda": {"name": "from-mtime"},
+        "from-invalid-string-1.0-0.conda": {
+            "name": "from-invalid-string",
+            "timestamp": "not-a-number",
+        },
+    }
+    with cache.db:
+        cache.db.executemany(
+            "INSERT INTO index_json (path, index_json) VALUES (?, json(?))",
+            [(path, json.dumps(record)) for path, record in records.items()],
+        )
+        cache.db.executemany(
+            "INSERT INTO stat (stage, path, mtime, size) VALUES (?, ?, ?, ?)",
+            [
+                (IndexedStages.INDEXED_STAGE.value, next(iter(records)), 2, 1),
+                (
+                    UpstreamStages.LOCAL_FILE_UPSTREAM_STAGE.value,
+                    list(records)[1],
+                    2.5,
+                    1,
+                ),
+                (
+                    UpstreamStages.LOCAL_FILE_UPSTREAM_STAGE.value,
+                    list(records)[2],
+                    2.75,
+                    1,
+                ),
+            ],
+        )
+
+    cache.backfill_indexed_timestamps()
+    first = {
+        row["path"]: row["indexed_timestamp"]
+        for row in cache.db.execute(
+            "SELECT path, indexed_timestamp FROM indexed_timestamp"
+        )
+    }
+    assert first == {
+        "from-builder-1.0-0.conda": 1500,
+        "from-mtime-1.0-0.conda": 2500,
+        "from-invalid-string-1.0-0.conda": 2750,
+    }
+    stored = {
+        row["path"]: json.loads(row["index_json"])
+        for row in cache.db.execute("SELECT path, index_json FROM index_json")
+    }
+    assert stored == records
+    emitted = cache.indexed_packages().packages_conda
+    assert {
+        path: record["indexed_timestamp"] for path, record in emitted.items()
+    } == first
+
+    with cache.db:
+        cache.db.execute("UPDATE stat SET mtime = 4")
+    cache.indexed_timestamp = 5000
+    cache.backfill_indexed_timestamps()
+    second = {
+        row["path"]: row["indexed_timestamp"]
+        for row in cache.db.execute(
+            "SELECT path, indexed_timestamp FROM indexed_timestamp"
+        )
+    }
+    assert second == first
+    assert {
+        row["path"]: json.loads(row["index_json"])
+        for row in cache.db.execute("SELECT path, index_json FROM index_json")
+    } == records
 
 
 def test_store_warns_when_member_data_missing(tmp_path, caplog):
@@ -187,6 +335,10 @@ def test_indexed_shards_warns_on_unsupported_extension(tmp_path, caplog):
                     }
                 ),
             ),
+        )
+        cache.db.execute(
+            "INSERT INTO indexed_timestamp (path, indexed_timestamp) VALUES (?, ?)",
+            ("pkg-1.0-0.unsupported", 1000),
         )
 
     shards = list(cache.indexed_shards())
@@ -365,6 +517,8 @@ def test_merge_index_cache(tmp_path):
                 f"INSERT INTO index_json (path, index_json) VALUES ('prefix/{subdir}.conda', '{{}}')"
             )
             migrate(conn)
+            if subdir == "noarch":
+                conn.execute("DROP TABLE indexed_timestamp")
 
     merge_index_cache(tmp_path)
 


### PR DESCRIPTION
### Description

Package `timestamp` is set by the builder, so clients cannot use it as a trusted cutoff for `--exclude-newer` and dependency cooldowns. This implements [CEP 47](https://conda.org/learn/ceps/cep-0047/) and #341 by assigning a server-controlled millisecond `indexed_timestamp` when `conda-index` first indexes each artifact.

The SQLite and PostgreSQL caches store the trusted value separately from package `index_json`. This preserves the original package metadata while classic, sharded, and v3 repodata receive the server-controlled value. Later indexing runs preserve it, and repodata patches cannot add or change it.

Existing cache records are backfilled once from package `timestamp`, then file modification time, then the current indexing time. Values later than the current indexing time are capped. V3 `oldest` and `newest` revision bounds now use `indexed_timestamp`.

Closes #341

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-index/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?