### PR TITLE
Add conda maintainers as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Syntax for this file at https://help.github.com/articles/about-codeowners/
+
+*       @conda/conda-maintainers


### PR DESCRIPTION
### Description

Assign `@conda/conda-maintainers` as the repository-wide code owner so GitHub requests reviews from the maintainer team for pull requests.

### Checklist - did you ...

- [x] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda-index/blob/main/news/TEMPLATE)) for the next release's release notes?~
- [x] ~Add / update necessary tests?~
- [x] ~Add / update outdated documentation?~