### PR TITLE
Add 3.14 as a tested Python version.

### DIFF
--- a/.github/workflows/canary-weekly.yml
+++ b/.github/workflows/canary-weekly.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         postgresql: [-db, '']
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         exclude:
           - os: windows-latest
             postgresql: -db

--- a/news/add-python-314-support
+++ b/news/add-python-314-support
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Add Python 3.14 to the GitHub Actions and Nox test matrices. (#351)

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,7 +4,7 @@ import nox
 @nox.session(venv_backend="conda")
 @nox.parametrize(
     "python",
-    [(python) for python in ("3.9", "3.10", "3.11", "3.12", "3.13")],
+    [(python) for python in ("3.9", "3.10", "3.11", "3.12", "3.13", "3.14")],
 )
 def tests(session):
     session.conda_install("conda", "conda-build")


### PR DESCRIPTION
### Description

Add Python 3.14 to the `tests.yml`, `canary-weekly.yml`, and Nox test matrices. The existing Python requirement and zstd dependency marker already support Python 3.14.

### Checklist - did you ...

- [x] Add a file to the `news` directory for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~~Add / update outdated documentation?~~
