### PR TITLE
Use conda Sphinx theme

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,13 +25,18 @@ updates:
     cooldown:
       default-days: 7
   - package-ecosystem: pip
-    directory: /docs/
+    directory: /
     schedule:
       interval: monthly
     allow:
-      # Allow only production updates for Sphinx
+      - dependency-name: conda-sphinx-theme
+      - dependency-name: mdit-py-plugins
+      - dependency-name: myst-parser
       - dependency-name: sphinx
-        dependency-type: production
+      - dependency-name: sphinx-argparse
+      - dependency-name: sphinx-copybutton
+      - dependency-name: sphinx-design
+      - dependency-name: sphinx-sitemap
     groups:
       docs:
         patterns:

--- a/.github/template-files/config.yml
+++ b/.github/template-files/config.yml
@@ -50,12 +50,13 @@ conda/infrastructure:
     dst: .github/PULL_REQUEST_TEMPLATE.md
 
   # [optional] dependabot
+  # extras: .github/template-files/templates/dependabot_extras.yml
   - src: templates/dependabot.yml
     dst: .github/dependabot.yml
     with:
       github_actions: true
       pre_commit: true
-      docs: pip
+      docs: false
 
   # [optional] rever release files
   # Select one of the following:

--- a/.github/template-files/templates/dependabot_extras.yml
+++ b/.github/template-files/templates/dependabot_extras.yml
@@ -1,0 +1,19 @@
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    allow:
+      - dependency-name: conda-sphinx-theme
+      - dependency-name: mdit-py-plugins
+      - dependency-name: myst-parser
+      - dependency-name: sphinx
+      - dependency-name: sphinx-argparse
+      - dependency-name: sphinx-copybutton
+      - dependency-name: sphinx-design
+      - dependency-name: sphinx-sitemap
+    groups:
+      docs:
+        patterns:
+          - '*'
+    cooldown:
+      default-days: 7

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -12,11 +12,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   sphinx:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Cache conda packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         env:
@@ -44,7 +50,7 @@ jobs:
           $CONDA/bin/conda create --quiet -n conda-index pip conda
           source $CONDA/envs/conda-index/bin/activate
           pip install -e ".[docs]"
-          make html
+          make html SPHINXOPTS="-W --keep-going"
       - name: Upload artifact
         id: deployment
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
@@ -55,7 +61,7 @@ jobs:
   pages:
 
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'push'
     needs: [sphinx]
 
     # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,10 +26,6 @@ repos:
         exclude: recipe/meta\.yaml
       # catch git merge/rebase problems
       - id: check-merge-conflict
-      # sort requirements files
-      - id: file-contents-sorter
-        files: docs/requirements\.txt
-        args: [--unique]
   # Python verification and formatting
   - repo: https://github.com/asottile/blacken-docs
     rev: dda8db18cfc68df532abf33b185ecd12d5b7b326  # frozen: 1.20.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,56 +1,65 @@
-# Configuration file for the Sphinx documentation builder.
-#
-# This file only contains a selection of the most common options. For a full
-# list see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
+"""Sphinx configuration for conda-index documentation."""
 
-# -- Path setup --------------------------------------------------------------
+from __future__ import annotations
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
 import os
 import sys
 
 sys.path.insert(0, os.path.abspath(".."))
 
+project = html_title = "conda-index"
+copyright = "2026, conda contributors"
+author = "conda contributors"
 
-# -- Project information -----------------------------------------------------
-
-project = "conda-index"
-copyright = "conda"
-author = "conda"
-
-
-# -- General configuration ---------------------------------------------------
-
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
 extensions = [
-    "sphinx.ext.autodoc",
     "myst_parser",
+    "sphinx.ext.autodoc",
+    "sphinx_copybutton",
+    "sphinx_design",
+    "sphinx_sitemap",
     "sphinxarg.ext",
 ]
 
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ["_templates"]
+myst_heading_anchors = 3
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "fieldlist",
+    "tasklist",
+]
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-# This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
+exclude_patterns = ["_build"]
 
+html_theme = "conda_sphinx_theme"
 
-# -- Options for HTML output -------------------------------------------------
+html_theme_options = {
+    "navigation_depth": -1,
+    "use_edit_page_button": True,
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/conda/conda-index",
+            "icon": "fa-brands fa-square-github",
+            "type": "fontawesome",
+        },
+        {
+            "name": "Zulip",
+            "url": "https://conda.zulipchat.com",
+            "icon": "fa-brands fa-zulip",
+            "type": "fontawesome",
+        },
+    ],
+}
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#
-html_theme = "furo"
+html_context = {
+    "github_user": "conda",
+    "github_repo": "conda-index",
+    "github_version": "main",
+    "doc_path": "docs",
+}
 
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_extra_path = ["robots.txt"]
+html_baseurl = "https://conda.github.io/conda-index/"
+
+sitemap_locales = [None]
+sitemap_url_scheme = "{link}"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,64 @@
-# Welcome to conda-index's documentation!
+# conda-index
 
-```{include} ../README.md
+`conda-index` creates conda channels from collections of conda packages. It
+extracts package metadata and writes the `repodata.json` and channel metadata
+that conda uses for dependency solving.
+
+Place packages in the matching platform subdirectories of a channel directory,
+including `noarch`, then create the index:
+
+```console
+$ conda index <path-to-channel>
 ```
+
+## Explore the documentation
+
+::::{grid} 1 1 2 2
+:gutter: 3
+
+:::{grid-item-card} {octicon}`terminal` Command-line interface
+:link: cli
+:link-type: doc
+
+Run `conda index` or `python -m conda_index` and look up every option.
+:::
+
+:::{grid-item-card} {octicon}`workflow` How indexing works
+:link: theory_of_operation
+:link-type: doc
+
+Follow package discovery, metadata caching, and repodata generation.
+:::
+
+:::{grid-item-card} {octicon}`database` Cache database
+:link: database
+:link-type: doc
+
+Inspect the SQLite metadata cache schema and sample queries.
+:::
+
+:::{grid-item-card} {octicon}`server` PostgreSQL
+:link: postgresql
+:link-type: doc
+
+Configure a shared PostgreSQL metadata database.
+:::
+
+:::{grid-item-card} {octicon}`code` Python API
+:link: modules
+:link-type: doc
+
+Use `update_index`, `ChannelIndex`, and the filesystem abstraction.
+:::
+
+:::{grid-item-card} {octicon}`log` Changelog
+:link: changelog
+:link-type: doc
+
+See what changed in each conda-index release.
+:::
+
+::::
 
 ## History
 
@@ -40,19 +97,32 @@
 * Reformat code.
 
 ```{toctree}
-:caption: 'Contents:'
-:maxdepth: 2
-cli
-theory_of_operation
-database
+:hidden:
+:caption: How-to guides
+
 postgresql
-v3-repodata
-modules
-changelog
 ```
 
-# Indices and tables
+```{toctree}
+:hidden:
+:caption: Reference
 
-- {ref}`genindex`
-- {ref}`modindex`
-- {ref}`search`
+cli
+database
+v3-repodata
+modules
+```
+
+```{toctree}
+:hidden:
+:caption: Explanation
+
+theory_of_operation
+```
+
+```{toctree}
+:hidden:
+:caption: Project
+
+changelog
+```

--- a/docs/postgresql.md
+++ b/docs/postgresql.md
@@ -36,7 +36,7 @@ URL](https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls).
 
 [The
 schema](https://github.com/conda/conda-index/blob/main/conda_index/postgres/model.py)
-is similar to the one [used for sqlite3](./database), except that while sqlite3
+is similar to the one [used for SQLite](database.md), except that while SQLite
 uses a database file per subdirectory, in PostgreSQL all subdirectories are
 stored in the same database. `conda_index` creates a random prefix in
 `[DIR]/.cache/cache.json` to differentiate this channel from any others that may

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,0 @@
-# docs
-conda-sphinx-theme>=0.4.0
-mdit-py-plugins>=0.3.0
-myst-parser>=3.0
-sphinx-argparse
-sphinx-copybutton>=0.5
-sphinx-design>=0.6
-sphinx-sitemap>=2.5
-sphinx>=9.1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,9 @@
 # docs
-furo
+conda-sphinx-theme>=0.4.0
 mdit-py-plugins>=0.3.0
-myst-parser>=2
-sphinx-click
+myst-parser>=3.0
+sphinx-argparse
+sphinx-copybutton>=0.5
+sphinx-design>=0.6
+sphinx-sitemap>=2.5
 sphinx>=9.1.0

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://conda.github.io/conda-index/sitemap.xml

--- a/docs/v3-repodata.md
+++ b/docs/v3-repodata.md
@@ -46,8 +46,7 @@ structure:
       "zstd-1.5.7-h817c040_0": {
         "build": "h817c040_0",
         "build_number": 0,
-        "depends": [...],
-        ...
+        "depends": []
       }
     },
     "tar.bz2": {},
@@ -83,17 +82,15 @@ Each per-package shard (stored as `<hash>.msgpack.zst`) looks something like thi
       "name": "arrow-c-glib",
       "build": "heb0d9f2_0",
       "build_number": 0,
-      "version": "23.0.1"
-      "depends": [...],
-      ...,
+      "version": "23.0.1",
+      "depends": [],
       "run_exports": {
         "weak": [
           "arrow-c-glib >=23.0.1,<23.0.2.0a0"
         ]
-      },
-      ...
+      }
     }
-  },
+  }
 }
 ```
 

--- a/news/conda-sphinx-theme.md
+++ b/news/conda-sphinx-theme.md
@@ -1,4 +1,4 @@
 ### Docs
 
-* Use `conda-sphinx-theme` for the documentation site and fail documentation
-  builds on warnings.
+* Use `conda-sphinx-theme` and task-oriented navigation for the documentation
+  site, and fail documentation builds on warnings.

--- a/news/conda-sphinx-theme.md
+++ b/news/conda-sphinx-theme.md
@@ -1,0 +1,4 @@
+### Docs
+
+* Use `conda-sphinx-theme` for the documentation site and fail documentation
+  builds on warnings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,14 @@ index = "conda_index.plugin"
 
 [project.optional-dependencies]
 docs = [
-  "furo",
-  "sphinx",
-  "sphinx-argparse",
-  "myst-parser",
+  "conda-sphinx-theme>=0.4.0",
   "mdit-py-plugins>=0.3.0",
+  "myst-parser>=3.0",
+  "sphinx>=7.0",
+  "sphinx-argparse",
+  "sphinx-copybutton>=0.5",
+  "sphinx-design>=0.6",
+  "sphinx-sitemap>=2.5",
 ]
 psql = [
   "psycopg2",


### PR DESCRIPTION
### Description

Use `conda-sphinx-theme` for the documentation site and align its configuration with the conda plugin projects. This adds GitHub and Zulip links, edit-page links, copy buttons, sitemap metadata, and strict warning handling while preserving the existing `.html` URLs used by GitHub Pages.

The landing page now uses `sphinx-design` cards and groups the existing pages as how-to guides, reference, explanation, and project information. It does not add a tutorial category because there is no guided tutorial yet.

Documentation dependencies now live only in `[project.optional-dependencies].docs`. The root Dependabot updater and its infrastructure template input track that single source.

The strict build also required fixing the PostgreSQL document link and making the two repodata examples valid JSON.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-index/blob/main/news/TEMPLATE)) for the next release's release notes?
- [ ] ~~Add / update necessary tests?~~
- [x] Add / update outdated documentation?